### PR TITLE
Fix gradient picker typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# web
+# Web Project
+
+This repository hosts experimental UI work located under `gridprj`. The
+main development happens in the `files/src` folder which now contains a
+structured source hierarchy:
+
+```
+files/src
+├── asset           # static assets such as icon definitions
+├── core            # base classes and utility modules
+├── data            # sample data used by the UI
+├── db              # database constants
+├── dom             # DOM related utilities and components
+├── intl            # i18n helpers
+├── prototypes      # prototype extensions
+├── ui              # user interface widgets
+├── utils           # general utilities
+└── main.js         # entry point that wires everything together
+```
+
+The `grild` directory holds HTML demos that load scripts from `files/src`.
+You can simply open one of these files (for example `gridprj/grild/grid.html`)
+in a modern browser to run the project. No additional build step is required
+as the code consists of plain JavaScript modules.

--- a/gridprj/files/src/ui/colorpicker/TbaseGradientPicker.js
+++ b/gridprj/files/src/ui/colorpicker/TbaseGradientPicker.js
@@ -3,7 +3,7 @@ import { TbasePicker } from './TbasePicker.js';
 import { TsingleColorPicker } from './TsingleColorPicker.js';
 import { translayer } from './utils.js';
 
-export class TaseGradientPicker extends TbasePicker {
+export class TbaseGradientPicker extends TbasePicker {
     initData() {
         this.gradientAngle = 0;
         this.centerPos = { x: 50, y: 50 };

--- a/gridprj/files/src/ui/colorpicker/TgradientPicker.js
+++ b/gridprj/files/src/ui/colorpicker/TgradientPicker.js
@@ -1,6 +1,6 @@
-import { TaseGradientPicker } from './TaseGradientPicker.js';
+import { TbaseGradientPicker } from './TbaseGradientPicker.js';
 
-export class TgradientPicker extends TaseGradientPicker {
+export class TgradientPicker extends TbaseGradientPicker {
     static #inst;
 
     static getInstance(opts = {}) {


### PR DESCRIPTION
## Summary
- correct `TbaseGradientPicker` class name
- update gradient picker import

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68820aac398c83309b186b462d77aad7