### PR TITLE
Update Twindow placement logic

### DIFF
--- a/gridprj/files/src/ui/Twindow.js
+++ b/gridprj/files/src/ui/Twindow.js
@@ -142,6 +142,7 @@ export class Twindow extends extendsClass(TdialogMixin, TframeMixin, Tpositioned
     #overlay = null;
     #modalPromise = null;
     #resolveModal = null;
+    #savedParent = null;
 
     constructor(opts = {}) {
         super('div', opts);
@@ -189,13 +190,59 @@ export class Twindow extends extendsClass(TdialogMixin, TframeMixin, Tpositioned
             this.#resolveModal = res;
         });
     };
-    
+
+    #rememberParent() {
+        if (!this.#savedParent) {
+            this.#savedParent = this.parent || this.htmlObject.parentElement;
+        }
+    }
+
+    #restoreParent() {
+        if (this.#savedParent) {
+            if (this.#savedParent.appendChild) {
+                this.#savedParent.appendChild(this);
+            } else {
+                this.#savedParent.appendChild(this.htmlObject);
+            }
+        } else if (this.parent) {
+            this.parent.removeChild(this);
+        }
+        this.#savedParent = null;
+    }
+
+    #ensurePlacement(names) {
+        names = Array.isArray(names) ? names : [names];
+        let node = this.parent;
+        while (node) {
+            for (const n of names) {
+                if (node.subLayers?.[n]) {
+                    if (this.parent !== node.subLayers[n]) {
+                        this.#rememberParent();
+                        node.subLayers[n].appendChild(this);
+                    }
+                    return;
+                }
+            }
+            node = node.parent;
+        }
+        for (const n of names) {
+            if (DOM.baseLayer.subLayers[n]) {
+                if (this.parent !== DOM.baseLayer.subLayers[n]) {
+                    this.#rememberParent();
+                    DOM.baseLayer.subLayers[n].appendChild(this);
+                }
+                return;
+            }
+        }
+    }
+
     showModal(target = null, align = Ealign.center | Ealign.middle, dx = 0, dy = 0) {
-        if(this.htmlObject.parentElement.owner?.subLayers?.modal) 
+        this.#ensurePlacement('modal');
         return this.#open(true, DOM.getHtmlElement(target), align, dx, dy);
     }
 
     showDialog(target = null, align, dx, dy) {
+        this.#ensurePlacement(['popup', 'windows']);
         return this.#open(false, DOM.getHtmlElement(target), align, dx, dy);
     }
     
@@ -204,6 +251,7 @@ export class Twindow extends extendsClass(TdialogMixin, TframeMixin, Tpositioned
         this.#removeBackdrop();
         this.#resolveModal?.(result);
         this.#modalPromise = null;
+        this.#restoreParent();
     }
 
     close(result) {

--- a/gridprj/tests/twindow.test.mjs
+++ b/gridprj/tests/twindow.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'assert';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost' });
+global.window = dom.window;
+global.document = dom.window.document;
+
+// Load modules
+const { DOM } = await import('../files/src/dom/dom.js');
+const { Twindow } = await import('../files/src/ui/Twindow.js');
+
+// trigger DOM load handlers
+document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+const win = new Twindow();
+win.showModal();
+assert.strictEqual(win.parent, DOM.baseLayer.subLayers.modal, 'placed in modal layer');
+win.hide();
+assert.strictEqual(win.parent, null, 'removed on hide');
+
+const dlg = new Twindow();
+dlg.showDialog();
+const defLayer = DOM.baseLayer.subLayers.popup || DOM.baseLayer.subLayers.windows;
+assert.strictEqual(dlg.parent, defLayer, 'dialog placed in popup/windows');
+dlg.hide();
+assert.strictEqual(dlg.parent, null, 'dialog removed on hide');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- support automatic layer placement for modal and dialog windows
- restore window parent when hiding
- add test covering auto-placement behavior

## Testing
- `node tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68854869355c83309aed1d31c907fa5f