### PR TITLE
Fix movable window caption and gradient picker

### DIFF
--- a/gridprj/files/src/dom/dom.js
+++ b/gridprj/files/src/dom/dom.js
@@ -740,8 +740,8 @@ export const DOM = {
             }
         }
 
-        const onPointerDown = e => {
-            if (e.target !== handle) return;
+        const onPointerDown = e => {
+            if (!handle.contains(e.target) || e.target.closest('button')) return;
             if (INTERACTION_STATE.get(element)) return;
             INTERACTION_STATE.set(element, 'moving');
             onMoveStartCb?.();

--- a/gridprj/files/src/ui/colorpicker/TmultiRadialGradientPicker.js
+++ b/gridprj/files/src/ui/colorpicker/TmultiRadialGradientPicker.js
@@ -184,7 +184,7 @@ export class TmultiRadialGradientPicker extends TbasePicker {
         const box = document.createElement("div");
         box.style.cssText = "position:absolute;z-index:3000;top:0;left:0;";
         document.body.appendChild(box);
-        new TsingleColorPicker({
+        let cp = new TsingleColorPicker({
           container: box,
           defaultColor: stop.color,
           onChange: col => {
@@ -193,9 +193,12 @@ export class TmultiRadialGradientPicker extends TbasePicker {
             this.updatePreview();
           },
           onClose: () => {
+            cp.destroy();
             document.body.removeChild(box);
           }
         });
+        cp.body();
+        cp.show();
       };
       this.linerBar.appendChild(btn);
     });


### PR DESCRIPTION
## Summary
- allow clicking anywhere on caption bar to move a Twindow and ignore caption buttons
- open color picker when double clicking stop handles in multi radial gradient picker

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68861a3691bc8330b268759e0ee437c0