### PR TITLE
Fix movable window caption drag and gradient picker cleanup

### DIFF
--- a/gridprj/files/src/dom/dom.js
+++ b/gridprj/files/src/dom/dom.js
@@ -740,19 +740,19 @@ export const DOM = {
             }
         }
 
-        const onPointerDown = e => {
-            if (e.target !== handle) return;
-            if (INTERACTION_STATE.get(element)) return;
-            INTERACTION_STATE.set(element, 'moving');
-            onMoveStartCb?.();
+        const onPointerDown = e => {
+            if (!handle.contains(e.target) || e.target.closest('button')) return;
+            if (INTERACTION_STATE.get(element)) return;
+            INTERACTION_STATE.set(element, 'moving');
+            onMoveStartCb?.();
 
-            const te = element.owner;
-            if (te && !globs.selectionManager.has(te)) {
-                globs.selectionManager.forEach(el => el.htmlObject.classList.remove('selected'));
-                globs.selectionManager.clear();
-                globs.selectionManager.add(te);
-                te.htmlObject.classList.add('selected');
-            }
+            const te = element.owner;
+            if (te && globs.selectionManager && !globs.selectionManager.has(te)) {
+                globs.selectionManager.forEach(el => el.htmlObject.classList.remove('selected'));
+                globs.selectionManager.clear();
+                globs.selectionManager.add(te);
+                te.htmlObject.classList.add('selected');
+            }
             const threshold = 7;
             const rect = element.getBoundingClientRect();
             const nearEdge = (

--- a/gridprj/files/src/ui/colorpicker/TmultiRadialGradientPicker.js
+++ b/gridprj/files/src/ui/colorpicker/TmultiRadialGradientPicker.js
@@ -184,7 +184,7 @@ export class TmultiRadialGradientPicker extends TbasePicker {
         const box = document.createElement("div");
         box.style.cssText = "position:absolute;z-index:3000;top:0;left:0;";
         document.body.appendChild(box);
-        new TsingleColorPicker({
+        let cp = new TsingleColorPicker({
           container: box,
           defaultColor: stop.color,
           onChange: col => {
@@ -193,9 +193,12 @@ export class TmultiRadialGradientPicker extends TbasePicker {
             this.updatePreview();
           },
           onClose: () => {
-            document.body.removeChild(box);
+            cp.destroy();
+            if (box.parentNode) box.parentNode.removeChild(box);
           }
         });
+        cp.body();
+        cp.show();
       };
       this.linerBar.appendChild(btn);
     });


### PR DESCRIPTION
## Summary
- ensure selection manager exists before using in movable window handler
- safely remove color picker wrapper in multi radial gradient picker

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68861a3691bc8330b268759e0ee437c0