### PR TITLE
Add richer design editor demo

### DIFF
--- a/gridprj/grild/propeditor-demo.html
+++ b/gridprj/grild/propeditor-demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <title>Tasarım Editörü</title>
+  <link rel="stylesheet" href="../files/css/dom.css">
+  <link rel="stylesheet" href="../files/css/propeditor.css">
+  <style>
+    html,body{margin:0;height:100%;}
+    #app{display:flex;height:100%;}
+    #app button.active{font-weight:bold;}
+    .design-item{position:absolute;padding:4px;border:1px solid #333;background:#fff;cursor:move;}
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="propeditor-demo.js"></script>
+</body>
+</html>

--- a/gridprj/grild/propeditor-demo.js
+++ b/gridprj/grild/propeditor-demo.js
@@ -1,0 +1,117 @@
+import '../files/src/main.js';
+import { TpropEditor } from '../files/src/ui/prop-editor/TpropEditor.js';
+import { Ttree } from '../files/src/ui/prop-editor/Ttree.js';
+import { editorRegistry, TbaseEditor } from '../files/src/ui/prop-editor/editorRegistery.js';
+import { TtreeView } from '../files/src/ui/Ttreeview.js';
+import { DOM } from '../files/src/dom/dom.js';
+import { Tlayer } from '../files/src/dom/Tlayer.js';
+import { selectionManager } from '../files/src/core/globals.js';
+import { elementIcons, formIcons, layoutIcons } from '../files/src/asset/icons copy.js';
+
+class TsliderEditor extends TbaseEditor {
+  render(){
+    const input = document.createElement('input');
+    input.type = 'range';
+    input.min = 0;
+    input.max = 1000;
+    input.value = this.initialValue || 0;
+    input.addEventListener('input', () => this._updateValue(parseFloat(input.value)));
+    return input;
+  }
+}
+
+editorRegistry.register((v,k) => typeof v === 'number' && /(width|height|left|top)/i.test(k), TsliderEditor);
+
+document.addEventListener('DOMContentLoaded', () => {
+  const app = document.getElementById('app');
+  app.style.flex = '1';
+  app.style.display = 'flex';
+
+  const left = document.createElement('div');
+  left.style.cssText = 'width:220px;border-right:1px solid #ccc;display:flex;flex-direction:column;';
+  const tabs = document.createElement('div');
+  tabs.style.cssText = 'display:flex;';
+  const btnElements = document.createElement('button');
+  btnElements.textContent = 'Elemanlar';
+  const btnLayers = document.createElement('button');
+  btnLayers.textContent = 'Katmanlar';
+  tabs.append(btnElements, btnLayers);
+  const leftContent = document.createElement('div');
+  leftContent.style.cssText = 'flex:1;overflow:auto;';
+  left.append(tabs, leftContent);
+
+  const designArea = document.createElement('div');
+  designArea.style.cssText = 'flex:1;position:relative;overflow:auto;';
+
+  const right = document.createElement('div');
+  right.style.cssText = 'width:300px;border-left:1px solid #ccc;overflow:auto;';
+
+  app.append(left, designArea, right);
+
+  // Tab panel
+  const elementTreeContainer = document.createElement('div');
+  const elementTree = new Ttree(elementTreeContainer);
+  const treeData = {
+    Yapı: { Div:{}, Section:{}, Header:{}, Footer:{} },
+    Form: { Form:{}, Input:{}, Button:{} }
+  };
+  elementTree.build(treeData, 'HTML');
+
+  // Add icons to tree labels
+  elementTree.container.querySelectorAll('.tree-node').forEach(el => {
+    const tag = el.treeNodeInstance.data.key.toLowerCase();
+    const ic = elementIcons[tag]?.icon || formIcons[tag]?.icon || layoutIcons[tag]?.icon;
+    if (ic) el.querySelector('.label').innerHTML = ic + ' ' + tag;
+  });
+
+  const layerTreeContainer = document.createElement('div');
+  let currentTab = null;
+  function showTab(tab){
+    leftContent.innerHTML = '';
+    btnElements.classList.toggle('active', tab === 'elements');
+    btnLayers.classList.toggle('active', tab === 'layers');
+    currentTab = tab;
+    if(tab === 'elements') leftContent.appendChild(elementTreeContainer);
+    else leftContent.appendChild(layerTreeContainer);
+  }
+  btnElements.onclick = () => showTab('elements');
+  btnLayers.onclick = () => showTab('layers');
+  showTab('elements');
+
+  // Root layer for design items
+  const rootLayer = new Tlayer(designArea, { layerName: 'root' });
+  const layerTree = new TtreeView(layerTreeContainer, rootLayer);
+
+  // Prop editor
+  const propEditor = new TpropEditor();
+  propEditor.body(right);
+  propEditor.show();
+
+  // Add item when double clicked in element tree
+  elementTree.container.addEventListener('dblclick', e => {
+    const nodeEl = e.target.closest('.tree-node');
+    if (!nodeEl || !nodeEl.treeNodeInstance) return;
+    const tag = nodeEl.treeNodeInstance.data.key.toLowerCase();
+    const layer = new Tlayer(tag, { parent: rootLayer });
+    layer.htmlObject.classList.add('design-item');
+    layer.htmlObject.textContent = tag;
+    layer.moveOptions.handle = null;
+    DOM.makeMovable(layer.htmlObject, null, designArea);
+    layer.htmlObject.style.left = '10px';
+    layer.htmlObject.style.top = '10px';
+    layer.htmlObject.addEventListener('pointerdown', ev => {
+      ev.stopPropagation();
+      layer.select();
+      propEditor.setTarget(layer, layer.layerName);
+    });
+  });
+
+  // Update prop editor on selection change
+  selectionManager.addEventListener('change', ({ detail }) => {
+    if (detail.action === 'select') {
+      propEditor.setTarget(detail.item, detail.item.layerName || 'Element');
+    }
+  });
+
+  designArea.addEventListener('pointerdown', () => selectionManager.clear());
+});


### PR DESCRIPTION
## Summary
- create slider-based editor via registry
- build HTML element palette with icons
- tweak demo page title

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_688650496c988330bfdf350f92918219