### PR TITLE
Fix dataset attribute and improve tree hierarchy

### DIFF
--- a/gridprj/files/src/dom/Tlayer.js
+++ b/gridprj/files/src/dom/Tlayer.js
@@ -54,7 +54,7 @@ export class Tlayer extends Telement {
         if (this._isLayer) return;
         Object.defineProperty(this, '_isLayer', { value: true, writable: false, enumerable: false });
 
-        this.htmlObject.dataset.layerID= this.id;
+        this.htmlObject.dataset.layerId = this.id;
        this.htmlObject.dataset.layerName=  options.layerName || this.name;
         this.subLayers = {};
         this.#changeListeners = [];

--- a/gridprj/grild/propeditor-demo.js
+++ b/gridprj/grild/propeditor-demo.js
@@ -56,16 +56,21 @@ document.addEventListener('DOMContentLoaded', () => {
   const elementTreeContainer = document.createElement('div');
   const elementTree = new Ttree(elementTreeContainer);
 
-  // Build tree from HTML_TAGS groups
-  const groups = {};
-  for (const [tag, info] of Object.entries(HTML_TAGS)) {
-    const grps = info.groupName || ['Other'];
-    grps.forEach(g => {
-      if (!groups[g]) groups[g] = {};
-      groups[g][tag] = {};
-    });
+  // Build tree using parent relationships for better hierarchy
+  function buildTree(parent) {
+    const branch = {};
+    for (const [tag, info] of Object.entries(HTML_TAGS)) {
+      let parents = info.parentTag;
+      if (!parents) parents = ['html'];
+      if (!Array.isArray(parents)) parents = [parents];
+      if (parents.some(p => (p || 'html').toLowerCase() === parent.toLowerCase())) {
+        branch[tag] = buildTree(tag);
+      }
+    }
+    return branch;
   }
-  elementTree.build(groups, 'HTML');
+  const treeData = { html: buildTree('html') };
+  elementTree.build(treeData, 'HTML');
 
   // Decorate labels with icons (if any)
   elementTree.container.querySelectorAll('.tree-node').forEach(el => {
@@ -100,11 +105,33 @@ document.addEventListener('DOMContentLoaded', () => {
   propEditor.show();
 
   // Add item when double clicked in element tree
+  function allowedParent(childTag, parentTag) {
+    const info = HTML_TAGS[childTag];
+    if (!info || !info.parentTag) return true;
+    const parents = Array.isArray(info.parentTag) ? info.parentTag : [info.parentTag];
+    return parents.map(p => (p || '').toLowerCase()).includes(parentTag.toLowerCase());
+  }
+
   elementTree.container.addEventListener('dblclick', e => {
     const nodeEl = e.target.closest('.tree-node');
     if (!nodeEl || !nodeEl.treeNodeInstance) return;
     const tag = nodeEl.treeNodeInstance.data.key.toLowerCase();
-    const layer = new Tlayer(tag, { parent: rootLayer });
+
+    let parentLayer = rootLayer;
+    const selected = selectionManager.selection.slice(-1)[0];
+    if (selected && allowedParent(tag, selected.tagName.toLowerCase())) {
+      parentLayer = selected;
+    } else if (selected) {
+      const parent = selected.parent;
+      if (parent && allowedParent(tag, parent.tagName.toLowerCase())) {
+        parentLayer = parent;
+      } else if (!allowedParent(tag, 'body')) {
+        // not allowed anywhere sensible
+        return;
+      }
+    }
+
+    const layer = new Tlayer(tag, { parent: parentLayer });
     layer.htmlObject.classList.add('design-item');
     layer.htmlObject.textContent = tag;
     layer.moveOptions.handle = null;


### PR DESCRIPTION
## Summary
- fix dataset attribute name to `layerId`
- build element tree using parent relationships
- insert new elements under selected parent when allowed

## Testing
- `node tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6887b7b623d08330a6613edf90ecd1ba