### PR TITLE
Fix propeditor layout behavior

### DIFF
--- a/gridprj/grild/propeditor-demo.html
+++ b/gridprj/grild/propeditor-demo.html
@@ -9,7 +9,9 @@
     html,body{margin:0;height:100%;}
     #app{display:flex;height:100%;}
     #app button.active{font-weight:bold;}
-    .design-item{position:absolute;padding:4px;border:1px solid #333;background:#fff;cursor:move;}
+    .design-item{padding:4px;border:1px solid #333;background:#fff;cursor:move;}
+    .layout-item{position:absolute;}
+    .tree-node.disabled{opacity:0.5;pointer-events:none;}
         .tree-view{font:13px sans-serif;user-select:none;}
     .tree-node{display:flex;align-items:center;white-space:nowrap;cursor:pointer;}
     .tree-node .toggle{width:1em;display:inline-block;text-align:center;user-select:none;}

--- a/gridprj/grild/propeditor-demo.js
+++ b/gridprj/grild/propeditor-demo.js
@@ -90,6 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
       el.querySelector('.label').innerHTML = info.icon + ' ' + tag;
     }
   });
+  updateTreeDisabled();
 
   const layerTreeContainer = document.createElement('div');
   let currentTab = null;
@@ -122,6 +123,16 @@ document.addEventListener('DOMContentLoaded', () => {
     return parents.map(p => (p || '').toLowerCase()).includes(parentTag.toLowerCase());
   }
 
+  function updateTreeDisabled(){
+    const selected = selectionManager.selection.slice(-1)[0];
+    const selTag = selected === rootLayer ? 'body' : selected?.htmlObject?.tagName?.toLowerCase();
+    elementTree.container.querySelectorAll('.tree-node').forEach(el => {
+      const tag = el.treeNodeInstance.data.key.toLowerCase();
+      const allowed = allowedParent(tag, selTag || 'body');
+      el.classList.toggle('disabled', !allowed);
+    });
+  }
+
   elementTree.container.addEventListener('dblclick', e => {
     const nodeEl = e.target.closest('.tree-node');
     if (!nodeEl || !nodeEl.treeNodeInstance) return;
@@ -129,7 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let parentLayer = rootLayer;
     const selected = selectionManager.selection.slice(-1)[0];
-    const selTag = selected === rootLayer ? 'body' : selected?.tagName?.toLowerCase();
+    const selTag = selected === rootLayer ? 'body' : selected?.htmlObject?.tagName?.toLowerCase();
     if (selected && allowedParent(tag, selTag)) {
       parentLayer = selected;
     } else if (selected) {
@@ -146,17 +157,23 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const layer = new Tlayer(tag, { parent: parentLayer });
+    const info = HTML_TAGS[tag];
+    const isLayout = info?.groupName?.includes('Layout');
     layer.htmlObject.classList.add('design-item');
+    if (isLayout) {
+      layer.htmlObject.classList.add('layout-item');
+      layer.moveOptions.handle = null;
+      DOM.makeMovable(layer.htmlObject, null, designArea);
+      layer.htmlObject.style.left = '10px';
+      layer.htmlObject.style.top = '10px';
+    }
     layer.htmlObject.textContent = tag;
-    layer.moveOptions.handle = null;
-    DOM.makeMovable(layer.htmlObject, null, designArea);
-    layer.htmlObject.style.left = '10px';
-    layer.htmlObject.style.top = '10px';
     layer.htmlObject.addEventListener('pointerdown', ev => {
       ev.stopPropagation();
       layer.select();
       propEditor.setTarget(layer, layer.layerName);
     });
+    updateTreeDisabled();
   });
 
   // Update prop editor on selection change
@@ -164,6 +181,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (detail.action === 'select') {
       propEditor.setTarget(detail.item, detail.item.layerName || 'Element');
     }
+    updateTreeDisabled();
   });
 
   designArea.addEventListener('pointerdown', () => selectionManager.clear());


### PR DESCRIPTION
## Summary
- ensure parent tag detection checks `htmlObject.tagName`
- add disabled highlighting for invalid elements
- position only layout elements absolutely
- update styles for layout items and disabled tree nodes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887d2397c648330a33bf0e155eab29e