### PR TITLE
Fix rootLayer init order

### DIFF
--- a/gridprj/grild/propeditor-demo.js
+++ b/gridprj/grild/propeditor-demo.js
@@ -90,7 +90,6 @@ document.addEventListener('DOMContentLoaded', () => {
       el.querySelector('.label').innerHTML = info.icon + ' ' + tag;
     }
   });
-  updateTreeDisabled();
 
   const layerTreeContainer = document.createElement('div');
   let currentTab = null;
@@ -109,6 +108,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // Root layer for design items
   const rootLayer = new Tlayer(designArea, { layerName: 'root' });
   const layerTree = new TtreeView(layerTreeContainer, rootLayer);
+
+  updateTreeDisabled();
 
   // Prop editor
   const propEditor = new TpropEditor();


### PR DESCRIPTION
## Summary
- fix ReferenceError in `propeditor-demo.js` by calling `updateTreeDisabled` after `rootLayer` is created

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6887d4f926fc83309770004f252d95ee