### PR TITLE
Fix tree insertion rules

### DIFF
--- a/gridprj/grild/propeditor-demo.js
+++ b/gridprj/grild/propeditor-demo.js
@@ -122,9 +122,24 @@ document.addEventListener('DOMContentLoaded', () => {
   // Add item when double clicked in element tree
   function allowedParent(childTag, parentTag) {
     const info = HTML_TAGS[childTag];
-    if (!info || !info.parentTag) return true;
+    if (!info) return true;
+
+    parentTag = (parentTag || '').toLowerCase();
+
+    // div and span are treated as generic containers
+    if (parentTag === 'div' || parentTag === 'span') return true;
+
+    if (!info.parentTag) return true;
+
     const parents = Array.isArray(info.parentTag) ? info.parentTag : [info.parentTag];
-    return parents.map(p => (p || '').toLowerCase()).includes(parentTag.toLowerCase());
+    const normalized = parents.map(p => (p || '').toLowerCase());
+
+    if (normalized.includes(parentTag)) return true;
+
+    // TextFormat elements should be allowed inside most tags
+    if (info.groupName && info.groupName.includes('TextFormat')) return true;
+
+    return false;
   }
 
   function updateTreeDisabled(){


### PR DESCRIPTION
## Summary
- allow drag/drop tags inside div/span and text formatting parents

## Testing
- `node tests/twindow.test.mjs` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68891ce6dc2c8330961a77460912a306