### PR TITLE
feat: improve style editor controls and update tests

### DIFF
--- a/gridprj/files/js/src/ui/style-editor/StyleEditor.js
+++ b/gridprj/files/js/src/ui/style-editor/StyleEditor.js
@@ -20,6 +20,37 @@ export class StyleEditor {
     }
 
     /**
+     * Verilen select ve tetikleyici elementi kullanarak özellik seçim arayüzü kurar.
+     * @param {HTMLSelectElement} selectEl - CSS özellik adlarının doldurulacağı select.
+     * @param {HTMLElement} triggerEl - Seçimi uygulamak için kullanılacak buton veya element.
+     */
+    bindPropertySelector(selectEl, triggerEl) {
+        if (!selectEl) return;
+
+        // Select içerisini tüm bilinen CSS özellikleriyle doldur.
+        selectEl.innerHTML = '';
+        Object.keys(cssProps.properties).forEach(prop => {
+            const opt = document.createElement('option');
+            opt.value = prop;
+            opt.textContent = prop;
+            selectEl.appendChild(opt);
+        });
+
+        const loadSelected = () => {
+            const selected = selectEl.value;
+            if (selected) {
+                this.renderControl(selected);
+            }
+        };
+
+        if (triggerEl) {
+            triggerEl.addEventListener('click', loadSelected);
+        } else {
+            selectEl.addEventListener('change', loadSelected);
+        }
+    }
+
+    /**
      * Belirli bir CSS özelliği için düzenleme arayüzünü oluşturur ve gösterir.
      * @param {string} styleProp - Düzenlenecek CSS özelliği (örn: 'backgroundColor').
      */
@@ -50,5 +81,117 @@ export class StyleEditor {
         wrapper.appendChild(control);
 
         this.editorContainer.appendChild(wrapper);
+    }
+
+    /**
+     * Birden fazla CSS özelliğini tablo halinde düzenlemek için genel bir yardımcı.
+     * Özellik adı solda, düzenleme kontrolü sağda yer alır.
+     * Sonuç, içeriği gizli yerel bir "scrollbox" ile sarılmış olarak sunulur.
+     * @param {string[]} propList - Düzenlenecek CSS özelliklerinin listesi.
+     */
+    renderProperties(propList) {
+        this.editorContainer.innerHTML = '';
+
+        const viewport = document.createElement('div');
+        viewport.style.cssText = 'position:relative;height:300px;overflow:hidden;border:1px solid #ccc;';
+        const content = document.createElement('div');
+        content.style.cssText = 'position:absolute;top:0;left:0;right:0;';
+        viewport.appendChild(content);
+
+        propList.forEach(prop => {
+            const row = document.createElement('div');
+            row.style.cssText = 'display:flex;align-items:center;padding:4px 8px;gap:8px;';
+
+            const label = document.createElement('div');
+            label.textContent = prop;
+            label.style.cssText = 'flex:1;white-space:nowrap;';
+
+            const controlWrap = document.createElement('div');
+            controlWrap.style.cssText = 'flex:1;';
+            const control = ControlFactory.createControl(prop, this.targetElement, val => {
+                this.targetElement.style[prop] = val;
+            });
+            controlWrap.appendChild(control);
+
+            row.append(label, controlWrap);
+            content.appendChild(row);
+        });
+
+        // Basit özel scroll çubuğu
+        const track = document.createElement('div');
+        track.style.cssText = 'position:absolute;top:0;right:2px;width:8px;height:100%;background:rgba(0,0,0,0.1);border-radius:4px;';
+        const thumb = document.createElement('div');
+        thumb.style.cssText = 'position:absolute;top:0;left:0;width:100%;background:rgba(0,0,0,0.4);border-radius:4px;';
+        track.appendChild(thumb);
+        viewport.appendChild(track);
+
+        let contentTop = 0;
+        const updateScrollbar = () => {
+            const total = content.scrollHeight;
+            const view = viewport.clientHeight;
+            const maxScroll = total - view;
+            if (maxScroll <= 0) {
+                track.style.display = 'none';
+                contentTop = 0;
+                content.style.top = '0px';
+                return;
+            }
+            track.style.display = '';
+            const ratio = view / total;
+            const thumbHeight = Math.max(ratio * view, 20);
+            thumb.style.height = thumbHeight + 'px';
+            const thumbMax = view - thumbHeight;
+            thumb.style.top = (-contentTop / maxScroll) * thumbMax + 'px';
+        };
+
+        const scrollBy = delta => {
+            const total = content.scrollHeight;
+            const view = viewport.clientHeight;
+            const maxScroll = total - view;
+            contentTop = Math.min(0, Math.max(-maxScroll, contentTop - delta));
+            content.style.top = contentTop + 'px';
+            updateScrollbar();
+        };
+
+        viewport.addEventListener('wheel', e => {
+            e.preventDefault();
+            scrollBy(e.deltaY);
+        });
+
+        let startY = 0;
+        let startTop = 0;
+        const onMouseMove = e => {
+            const view = viewport.clientHeight;
+            const thumbHeight = thumb.offsetHeight;
+            const thumbMax = view - thumbHeight;
+            let newTop = startTop + (e.clientY - startY);
+            newTop = Math.max(0, Math.min(thumbMax, newTop));
+            thumb.style.top = newTop + 'px';
+            const total = content.scrollHeight;
+            const maxScroll = total - view;
+            contentTop = -(newTop / thumbMax) * maxScroll;
+            content.style.top = contentTop + 'px';
+        };
+        const onMouseUp = () => {
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+        };
+        thumb.addEventListener('mousedown', e => {
+            e.preventDefault();
+            startY = e.clientY;
+            startTop = parseFloat(thumb.style.top) || 0;
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+        });
+
+        requestAnimationFrame(updateScrollbar);
+        this.editorContainer.appendChild(viewport);
+    }
+
+    /**
+     * Tüm bilinen CSS özellikleri için bir düzenleme listesi oluşturur.
+     */
+    renderAll() {
+        this.renderProperties(Object.keys(cssProps.properties));
     }
 }

--- a/gridprj/files/js/src/ui/style-editor/controls/TcolorControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcolorControl.js
@@ -2,6 +2,8 @@
 // Her kontrol, özelliğin türüne göre (renk, sayı, bileşik değer vb.) özelleşmiştir.
 import { TbaseControl } from './TbaseControl.js';
 import { TsingleColorPicker } from '../../colorpicker/TsingleColorPicker.js';
+// Renk isimleri listesi için cssProps'u ekliyoruz.
+import { cssProps } from '../../../data/cssProperties.js';
 
 export class TcolorControl extends TbaseControl {
     render() {
@@ -12,6 +14,17 @@ export class TcolorControl extends TbaseControl {
         textInput.type = 'text';
         textInput.value = this.initialValue;
         textInput.style.flex = '1';
+
+        // Hazır CSS renk isimlerini sunmak için datalist kullanıyoruz.
+        const listId = `${this.styleProp}-colors-${Math.random().toString(36).slice(2)}`;
+        textInput.setAttribute('list', listId);
+        const dataList = document.createElement('datalist');
+        dataList.id = listId;
+        (cssProps.colorNames || []).forEach(name => {
+            const opt = document.createElement('option');
+            opt.value = name;
+            dataList.appendChild(opt);
+        });
         
         const colorBox = document.createElement('div');
         colorBox.style.cssText = 'width: 28px; height: 28px; border: 1px solid #888; cursor: pointer;';
@@ -35,7 +48,7 @@ export class TcolorControl extends TbaseControl {
             });
         });
 
-        container.append(textInput, colorBox);
+        container.append(textInput, colorBox, dataList);
         return container;
     }
 }

--- a/gridprj/grild/style-editor-demo.html
+++ b/gridprj/grild/style-editor-demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Gelişmiş Style Editor Demo</title>
+  <link rel="stylesheet" href="../files/css/dom.css" />
+  <link rel="stylesheet" href="../files/css/propeditor.css" />
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    #wrapper { display: flex; gap: 20px; padding: 10px; }
+    #propList { width: 320px; }
+    #preview { width: 200px; height: 120px; border: 2px solid #333; }
+  </style>
+  <script type="module" src="style-editor-demo.js"></script>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="propList"></div>
+    <div id="preview">Örnek</div>
+  </div>
+</body>
+</html>
+

--- a/gridprj/grild/style-editor-demo.js
+++ b/gridprj/grild/style-editor-demo.js
@@ -1,0 +1,12 @@
+import '../files/js/src/main.js';
+import { StyleEditor } from '../files/js/src/ui/style-editor/StyleEditor.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const target = document.getElementById('preview');
+  const listContainer = document.getElementById('propList');
+
+  const editor = new StyleEditor(target, listContainer);
+  // Tüm bilinen özellikleri listele
+  editor.renderAll();
+});
+

--- a/gridprj/tests/twindow.test.mjs
+++ b/gridprj/tests/twindow.test.mjs
@@ -6,8 +6,10 @@ global.window = dom.window;
 global.document = dom.window.document;
 
 // Load modules
-const { DOM } = await import('../files/src/dom/dom.js');
-const { Twindow } = await import('../files/src/ui/Twindow.js');
+// 'src' klasörü artık 'files/js/src' konumuna taşındı.
+// Testlerdeki modül yollarını güncel konuma göre düzenliyoruz.
+const { DOM } = await import('../files/js/src/dom/dom.js');
+const { Twindow } = await import('../files/js/src/ui/Twindow.js');
 
 // trigger DOM load handlers
 document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));


### PR DESCRIPTION
## Summary
- add datalist-driven color suggestions in `TcolorControl`
- expose `bindPropertySelector` to simplify property selection UI
- update tests for relocated `src` directory
- render full property lists with a custom scrollbox via `StyleEditor.renderAll`
- include `style-editor-demo` showcasing multi-property editing

## Testing
- `npm install jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_688e0eeb4b98833086cef9040e715dd5