### PR TITLE
Add navigation path and search to property editor

### DIFF
--- a/gridprj/files/js/src/ui/prop-editor/TpropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TpropEditor.js
@@ -33,22 +33,35 @@ export class TpropEditor extends Twindow {
         super.body(parent);
         this.htmlObject.classList.add('prop-editor');
 
+        this.pathBar = document.createElement('div');
+        this.pathBar.className = 'prop-editor-path';
+        this.pathBar.style.cssText = 'padding:4px 8px;border-bottom:1px solid #ccc;white-space:nowrap;overflow:auto;';
+
+        this.searchInput = document.createElement('input');
+        this.searchInput.type = 'text';
+        this.searchInput.placeholder = 'Ara...';
+        this.searchInput.className = 'prop-editor-search';
+        this.searchInput.style.cssText = 'margin:4px;';
+
         this.treeContainer = document.createElement('div');
         this.treeContainer.style.cssText = 'flex: 1; overflow: auto; border-bottom: 1px solid #ccc;';
 
         this.editorContainer = document.createElement('div');
         this.editorContainer.style.cssText = 'padding: 10px; min-height: 100px;';
 
-        this.contentPanel.append(this.treeContainer, this.editorContainer);
+        this.contentPanel.append(this.pathBar, this.searchInput, this.treeContainer, this.editorContainer);
 
         this.tree = new Ttree(this.treeContainer);
         this.tree.on('select', (node) => this.renderEditorForNode(node));
+
+        this.searchInput.addEventListener('input', () => this.filterTree(this.searchInput.value));
     }
 
     setTarget(targetObject, name = 'Root') {
         this.currentTarget = targetObject;
         this.tree.build(targetObject, name);
         this.editorContainer.innerHTML = 'Bir özellik seçin...';
+        this.updatePath(this.tree.rootNode);
     }
 
     /**
@@ -71,6 +84,37 @@ export class TpropEditor extends Twindow {
             info.textContent = `Değer: ${String(value)} (Düzenlenemez)`;
             this.editorContainer.appendChild(info);
         }
+        this.updatePath(node);
+    }
+
+    filterTree(text) {
+        const term = text.toLowerCase();
+        this.treeContainer.querySelectorAll('.tree-node').forEach(el => {
+            const label = el.querySelector('.label').textContent.toLowerCase();
+            el.style.display = term && !label.includes(term) ? 'none' : '';
+        });
+    }
+
+    updatePath(node) {
+        const nodes = [];
+        let n = node;
+        while (n) {
+            nodes.unshift(n);
+            n = n.parentNode;
+        }
+        this.pathBar.innerHTML = '';
+        nodes.forEach((p, idx) => {
+            const sp = document.createElement('span');
+            sp.textContent = p.data.key;
+            sp.style.cursor = 'pointer';
+            sp.onclick = () => this.tree.selectNode(p);
+            this.pathBar.appendChild(sp);
+            if (idx < nodes.length - 1) {
+                const sep = document.createElement('span');
+                sep.textContent = ' \u203A ';
+                this.pathBar.appendChild(sep);
+            }
+        });
     }
 }
 window.TpropEditor = TpropEditor;

--- a/gridprj/files/js/src/ui/prop-editor/Ttree.js
+++ b/gridprj/files/js/src/ui/prop-editor/Ttree.js
@@ -2,9 +2,10 @@
  * TtreeNode: Ağaç yapısındaki her bir düğümü temsil eder.
  */
 class TtreeNode {
-    constructor(data, level = 0) {
+    constructor(data, level = 0, parentNode = null) {
         this.data = data; // { key, value, parent }
         this.level = level;
+        this.parentNode = parentNode;
         this.children = [];
         this.isExpanded = false;
 
@@ -14,7 +15,7 @@ class TtreeNode {
 
         this.toggle = document.createElement('span');
         this.toggle.className = 'toggle';
-        
+
         this.label = document.createElement('span');
         this.label.className = 'label';
         this.label.textContent = data.key;
@@ -50,13 +51,14 @@ export class Ttree extends EventTarget {
     build(obj, name = 'Root') {
         this.container.innerHTML = '';
         const rootData = { key: name, value: obj, parent: null };
-        const rootNode = this._createNode(rootData, 0);
+        const rootNode = this._createNode(rootData, 0, null);
+        this.rootNode = rootNode;
         this.container.appendChild(rootNode.htmlObject);
         this.toggleNode(rootNode); // Başlangıçta kök düğümü aç
     }
 
-    _createNode(data, level) {
-        const node = new TtreeNode(data, level);
+    _createNode(data, level, parentNode) {
+        const node = new TtreeNode(data, level, parentNode);
         node.htmlObject.treeNodeInstance = node; // DOM elementinden sınıfa geri referans
 
         const isExpandable = typeof data.value === 'object' && data.value !== null && Object.keys(data.value).length > 0;
@@ -79,7 +81,7 @@ export class Ttree extends EventTarget {
                 for (const key in value) {
                     if (Object.prototype.hasOwnProperty.call(value, key)) {
                         const childData = { key, value: value[key], parent: value };
-                        const childNode = this._createNode(childData, node.level + 1);
+                        const childNode = this._createNode(childData, node.level + 1, node);
                         node.children.push(childNode);
                         node.htmlObject.after(childNode.htmlObject);
                     }


### PR DESCRIPTION
## Summary
- show breadcrumb path of selected property
- add search box to filter property tree
- track parent nodes within tree to support navigation

## Testing
- `node tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e27a380dc8330843267f2941f22da