### PR TITLE
Improve property editor layout and navigation

### DIFF
--- a/gridprj/files/js/src/ui/prop-editor/TpropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TpropEditor.js
@@ -20,6 +20,7 @@ export class TpropEditor extends Twindow {
         this.currentTarget = null;
         this.contentPanel.style.display = 'flex';
         this.contentPanel.style.flexDirection = 'column';
+        this.nameColWidth = 150;
     }
 
     static getInstance(opts) {
@@ -33,22 +34,38 @@ export class TpropEditor extends Twindow {
         super.body(parent);
         this.htmlObject.classList.add('prop-editor');
 
+        this.pathBar = document.createElement('div');
+        this.pathBar.className = 'prop-editor-path';
+        this.pathBar.style.cssText = 'padding:4px 8px;border-bottom:1px solid #ccc;white-space:nowrap;overflow:auto;';
+
+        this.searchInput = document.createElement('input');
+        this.searchInput.type = 'text';
+        this.searchInput.placeholder = 'Ara...';
+        this.searchInput.className = 'prop-editor-search';
+        this.searchInput.style.cssText = 'margin:4px;';
+
         this.treeContainer = document.createElement('div');
         this.treeContainer.style.cssText = 'flex: 1; overflow: auto; border-bottom: 1px solid #ccc;';
 
         this.editorContainer = document.createElement('div');
         this.editorContainer.style.cssText = 'padding: 10px; min-height: 100px;';
 
-        this.contentPanel.append(this.treeContainer, this.editorContainer);
+        this.contentPanel.append(this.pathBar, this.searchInput, this.treeContainer, this.editorContainer);
 
         this.tree = new Ttree(this.treeContainer);
         this.tree.on('select', (node) => this.renderEditorForNode(node));
+
+        this.searchInput.addEventListener('input', () => this.filterTree(this.searchInput.value));
+
+        // Varsayılan olarak window nesnesini kök olarak ayarla
+        this.setTarget(window, 'window');
     }
 
-    setTarget(targetObject, name = 'Root') {
+    setTarget(targetObject, name = 'window') {
         this.currentTarget = targetObject;
         this.tree.build(targetObject, name);
         this.editorContainer.innerHTML = 'Bir özellik seçin...';
+        this.updatePath(this.tree.rootNode);
     }
 
     /**
@@ -59,18 +76,178 @@ export class TpropEditor extends Twindow {
         this.editorContainer.innerHTML = '';
         const { parent, key, value } = node.data;
 
-        // DEĞİŞİKLİK: Kayıt sistemine artık sadece değeri değil,
-        // ebeveyn nesneyi ve özellik adını da gönderiyoruz.
-        const EditorComponent = editorRegistry.getEditorFor(value, key, parent);
-        
-        if (EditorComponent) {
-            const editorInstance = new EditorComponent(parent, key);
-            this.editorContainer.appendChild(editorInstance.render());
+        if (value && typeof value === 'object') {
+            this.renderObjectProperties(value);
         } else {
-            const info = document.createElement('div');
-            info.textContent = `Değer: ${String(value)} (Düzenlenemez)`;
-            this.editorContainer.appendChild(info);
+            const EditorComponent = editorRegistry.getEditorFor(value, key, parent);
+            if (EditorComponent) {
+                const editorInstance = new EditorComponent(parent, key);
+                this.editorContainer.appendChild(editorInstance.render());
+            } else {
+                const info = document.createElement('div');
+                info.textContent = `Değer: ${String(value)} (Düzenlenemez)`;
+                this.editorContainer.appendChild(info);
+            }
         }
+        this.updatePath(node);
+    }
+
+    filterTree(text) {
+        const term = text.toLowerCase();
+        this.treeContainer.querySelectorAll('.tree-node').forEach(el => {
+            const label = el.querySelector('.label').textContent.toLowerCase();
+            el.style.display = term && !label.includes(term) ? 'none' : '';
+        });
+    }
+
+    updatePath(node) {
+        const nodes = [];
+        let n = node;
+        while (n) {
+            nodes.unshift(n);
+            n = n.parentNode;
+        }
+        this.pathBar.innerHTML = '';
+        nodes.forEach((p, idx) => {
+            const sp = document.createElement('span');
+            sp.textContent = p.data.key;
+            sp.style.cursor = 'pointer';
+            sp.onclick = (e) => {
+                e.stopPropagation();
+                this.tree.selectNode(p);
+                this.showNodeChildrenMenu(p, sp);
+            };
+            this.pathBar.appendChild(sp);
+            if (idx < nodes.length - 1) {
+                const sep = document.createElement('span');
+                sep.textContent = ' \u203A ';
+                this.pathBar.appendChild(sep);
+            }
+        });
+    }
+
+    showNodeChildrenMenu(node, anchor) {
+        if (!node.isExpanded) {
+            this.tree.toggleNode(node);
+        }
+        if (this.currentMenu) {
+            this.currentMenu.remove();
+        }
+        const menu = document.createElement('div');
+        menu.className = 'path-menu';
+        menu.style.cssText = 'position:absolute;background:#fff;border:1px solid #ccc;z-index:1000;';
+        node.children.forEach(child => {
+            const item = document.createElement('div');
+            item.textContent = child.data.key;
+            item.style.padding = '2px 6px';
+            item.style.cursor = 'pointer';
+            item.onclick = (e) => {
+                e.stopPropagation();
+                this.tree.selectNode(child);
+                menu.remove();
+                this.currentMenu = null;
+            };
+            menu.appendChild(item);
+        });
+        const rect = anchor.getBoundingClientRect();
+        menu.style.left = rect.left + 'px';
+        menu.style.top = (rect.bottom + window.scrollY) + 'px';
+        document.body.appendChild(menu);
+        this.currentMenu = menu;
+        const close = (ev) => {
+            if (!menu.contains(ev.target)) {
+                menu.remove();
+                this.currentMenu = null;
+                document.removeEventListener('click', close);
+            }
+        };
+        setTimeout(() => document.addEventListener('click', close), 0);
+    }
+
+    renderObjectProperties(obj) {
+        const list = document.createElement('div');
+        list.className = 'prop-list';
+        list.style.position = 'relative';
+
+        const handle = document.createElement('div');
+        handle.className = 'prop-splitter';
+        handle.style.cssText = `position:absolute;top:0;bottom:0;width:4px;cursor:col-resize;background:#ddd;right:${this.nameColWidth}px;`;
+
+        const rowsContainer = document.createElement('div');
+        rowsContainer.style.display = 'flex';
+        rowsContainer.style.flexDirection = 'column';
+
+        for (const key in obj) {
+            const row = document.createElement('div');
+            row.className = 'prop-row';
+            row.style.display = 'flex';
+            row.style.alignItems = 'center';
+
+            const valueCell = document.createElement('div');
+            valueCell.className = 'prop-value';
+            valueCell.style.flex = '1';
+
+            const nameCell = document.createElement('div');
+            nameCell.className = 'prop-name';
+            nameCell.style.width = this.nameColWidth + 'px';
+            nameCell.textContent = key;
+
+            const val = obj[key];
+            const EditorComponent = editorRegistry.getEditorFor(val, key, obj);
+            if (EditorComponent) {
+                const editorInstance = new EditorComponent(obj, key);
+                valueCell.appendChild(editorInstance.render());
+            } else {
+                if (typeof val === 'string') {
+                    const inp = document.createElement('input');
+                    inp.type = 'text';
+                    inp.value = val;
+                    inp.onchange = (e) => obj[key] = e.target.value;
+                    valueCell.appendChild(inp);
+                } else if (typeof val === 'number') {
+                    const inp = document.createElement('input');
+                    inp.type = 'number';
+                    inp.value = val;
+                    inp.onchange = (e) => obj[key] = Number(e.target.value);
+                    valueCell.appendChild(inp);
+                } else if (typeof val === 'boolean') {
+                    const inp = document.createElement('input');
+                    inp.type = 'checkbox';
+                    inp.checked = val;
+                    inp.onchange = (e) => obj[key] = e.target.checked;
+                    valueCell.appendChild(inp);
+                } else {
+                    const span = document.createElement('span');
+                    span.textContent = String(val);
+                    valueCell.appendChild(span);
+                }
+            }
+
+            row.append(valueCell, nameCell);
+            rowsContainer.appendChild(row);
+        }
+
+        list.appendChild(rowsContainer);
+        list.appendChild(handle);
+
+        const startDrag = (e) => {
+            e.preventDefault();
+            const onMove = (ev) => {
+                const rect = list.getBoundingClientRect();
+                this.nameColWidth = Math.max(50, rect.right - ev.clientX);
+                list.querySelectorAll('.prop-name').forEach(n => n.style.width = this.nameColWidth + 'px');
+                handle.style.right = this.nameColWidth + 'px';
+            };
+            const onUp = () => {
+                window.removeEventListener('mousemove', onMove);
+                window.removeEventListener('mouseup', onUp);
+            };
+            window.addEventListener('mousemove', onMove);
+            window.addEventListener('mouseup', onUp);
+        };
+        handle.addEventListener('mousedown', startDrag);
+
+        this.editorContainer.appendChild(list);
     }
 }
 window.TpropEditor = TpropEditor;

--- a/gridprj/files/js/src/ui/prop-editor/Ttree.js
+++ b/gridprj/files/js/src/ui/prop-editor/Ttree.js
@@ -2,9 +2,10 @@
  * TtreeNode: Ağaç yapısındaki her bir düğümü temsil eder.
  */
 class TtreeNode {
-    constructor(data, level = 0) {
+    constructor(data, level = 0, parentNode = null) {
         this.data = data; // { key, value, parent }
         this.level = level;
+        this.parentNode = parentNode;
         this.children = [];
         this.isExpanded = false;
 
@@ -14,7 +15,7 @@ class TtreeNode {
 
         this.toggle = document.createElement('span');
         this.toggle.className = 'toggle';
-        
+
         this.label = document.createElement('span');
         this.label.className = 'label';
         this.label.textContent = data.key;
@@ -47,21 +48,22 @@ export class Ttree extends EventTarget {
         });
     }
 
-    build(obj, name = 'Root') {
+    build(obj, name = 'window') {
         this.container.innerHTML = '';
         const rootData = { key: name, value: obj, parent: null };
-        const rootNode = this._createNode(rootData, 0);
+        const rootNode = this._createNode(rootData, 0, null);
+        this.rootNode = rootNode;
         this.container.appendChild(rootNode.htmlObject);
         this.toggleNode(rootNode); // Başlangıçta kök düğümü aç
     }
 
-    _createNode(data, level) {
-        const node = new TtreeNode(data, level);
+    _createNode(data, level, parentNode) {
+        const node = new TtreeNode(data, level, parentNode);
         node.htmlObject.treeNodeInstance = node; // DOM elementinden sınıfa geri referans
 
-        const isExpandable = typeof data.value === 'object' && data.value !== null && Object.keys(data.value).length > 0;
+        const isExpandable = this._hasProperties(data.value);
         node.toggle.innerHTML = isExpandable ? '►' : '';
-        
+
         return node;
     }
 
@@ -77,17 +79,23 @@ export class Ttree extends EventTarget {
             const value = node.data.value;
             if (typeof value === 'object' && value !== null) {
                 for (const key in value) {
-                    if (Object.prototype.hasOwnProperty.call(value, key)) {
-                        const childData = { key, value: value[key], parent: value };
-                        const childNode = this._createNode(childData, node.level + 1);
-                        node.children.push(childNode);
-                        node.htmlObject.after(childNode.htmlObject);
-                    }
+                    const childData = { key, value: value[key], parent: value };
+                    const childNode = this._createNode(childData, node.level + 1, node);
+                    node.children.push(childNode);
+                    node.htmlObject.after(childNode.htmlObject);
                 }
             }
             node.toggle.innerHTML = '▼';
             node.isExpanded = true;
         }
+    }
+
+    _hasProperties(obj) {
+        if (typeof obj !== 'object' || obj === null) return false;
+        for (const _ in obj) {
+            return true;
+        }
+        return false;
     }
 
     selectNode(node) {


### PR DESCRIPTION
## Summary
- start property editor from global window and show child objects via breadcrumb dropdown
- list object properties with values on the left and names on the right, separated by a draggable divider
- include inherited properties when expanding nodes in the property tree

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e27a380dc8330843267f2941f22da