### PR TITLE
feat: add resize start/end events

### DIFF
--- a/gridprj/files/js/src/dom/dom.js
+++ b/gridprj/files/js/src/dom/dom.js
@@ -463,6 +463,9 @@ export const DOM = {
             if (INTERACTION_STATE.get(el)) return;
             INTERACTION_STATE.set(el, 'resizing');
 
+            if (!("onresizestart" in el)) el.onresizestart = null;
+            el.dispatchEvent(new Event('resizestart'));
+
             const start = {
                 x: e.clientX, y: e.clientY,
                 left: el.offsetLeft,
@@ -501,6 +504,8 @@ export const DOM = {
                 el.removeEventListener('pointerup', onUp);
                 el.removeEventListener('pointercancel', onUp);
                 el.releasePointerCapture?.(ev.pointerId);
+                if (!("onresizeend" in el)) el.onresizeend = null;
+                el.dispatchEvent(new Event('resizeend'));
                 INTERACTION_STATE.delete(el);
             };
 
@@ -560,11 +565,14 @@ makeResizableWithHandles : function (el, flags) {
             el._resHandles.push(h);
             document.body.appendChild(h);
 
-            h.addEventListener('mousedown', e => {
-                e.preventDefault(); e.stopPropagation();
-                const startX = e.clientX, startY = e.clientY;
-                const { left, top, width, height } = rect();
-                const dirKey = dir;
+            h.addEventListener('mousedown', e => {
+                e.preventDefault(); e.stopPropagation();
+                const startX = e.clientX, startY = e.clientY;
+                const { left, top, width, height } = rect();
+                const dirKey = dir;
+
+                if (!("onresizestart" in el)) el.onresizestart = null;
+                el.dispatchEvent(new Event('resizestart'));
 
                 function onMove(ev) {
                     const dx = ev.clientX - startX, dy = ev.clientY - startY;
@@ -579,11 +587,16 @@ makeResizableWithHandles : function (el, flags) {
                     el.dispatchEvent(new Event('resize'));
                 }
 
-                document.addEventListener('mousemove', onMove);
-                document.addEventListener('mouseup', () => document.removeEventListener('mousemove', onMove), { once: true });
-            });
-        });
-    },
+                function onUp() {
+                    document.removeEventListener('mousemove', onMove);
+                    if (!("onresizeend" in el)) el.onresizeend = null;
+                    el.dispatchEvent(new Event('resizeend'));
+                }
+                document.addEventListener('mousemove', onMove);
+                document.addEventListener('mouseup', onUp, { once: true });
+            });
+        });
+    },
 
     /**
      * Attach edge-based resize (no handles), window-like behavior.
@@ -606,16 +619,18 @@ makeResizableWithHandles : function (el, flags) {
             el.style.cursor = RESIZE_CURSORS[dir] || '';
         }
 
-        function onDown(e) {
-            const r = rect(); const x = e.clientX - r.left, y = e.clientY - r.top;
-            let dir = '';
-            if (y < threshold && (flags & Eborder.top)) dir += 'n';
-            else if (y > r.height - threshold && (flags & Eborder.bottom)) dir += 's';
-            if (x < threshold && (flags & Eborder.left)) dir += 'w';
-            else if (x > r.width - threshold && (flags & Eborder.right)) dir += 'e';
-            if (!dir) return;
-            e.preventDefault();
-            const start = { x: e.clientX, y: e.clientY, ...r };
+        function onDown(e) {
+            const r = rect(); const x = e.clientX - r.left, y = e.clientY - r.top;
+            let dir = '';
+            if (y < threshold && (flags & Eborder.top)) dir += 'n';
+            else if (y > r.height - threshold && (flags & Eborder.bottom)) dir += 's';
+            if (x < threshold && (flags & Eborder.left)) dir += 'w';
+            else if (x > r.width - threshold && (flags & Eborder.right)) dir += 'e';
+            if (!dir) return;
+            e.preventDefault();
+            if (!("onresizestart" in el)) el.onresizestart = null;
+            el.dispatchEvent(new Event('resizestart'));
+            const start = { x: e.clientX, y: e.clientY, ...r };
 
             function onDrag(ev) {
                 const dx = ev.clientX - start.x, dy = ev.clientY - start.y;
@@ -633,9 +648,14 @@ makeResizableWithHandles : function (el, flags) {
                 el.dispatchEvent(new Event('resize'));
             }
 
-            document.addEventListener('mousemove', onDrag);
-            document.addEventListener('mouseup', () => document.removeEventListener('mousemove', onDrag), { once: true });
-        }
+            function onUp() {
+                document.removeEventListener('mousemove', onDrag);
+                if (!("onresizeend" in el)) el.onresizeend = null;
+                el.dispatchEvent(new Event('resizeend'));
+            }
+            document.addEventListener('mousemove', onDrag);
+            document.addEventListener('mouseup', onUp, { once: true });
+        }
 
         el.addEventListener('mousemove', onMove);
         el.addEventListener('mousedown', onDown);

--- a/gridprj/files/js/src/ui/Twindow.js
+++ b/gridprj/files/js/src/ui/Twindow.js
@@ -16,6 +16,7 @@ const TframeMixin = class TframeMixin {
         maxHeight = null,
         showCaption = true,
         movable = true,
+        resizable = true,
         parent = null
     } = {}) {
 
@@ -60,6 +61,16 @@ const TframeMixin = class TframeMixin {
         this.contentPanel.className = 'twindow-content';
         this.contentPanel.style.cssText = `flex:1 1 auto;overflow:auto;background:#fff;min-height:${minHeight - 30}px;position:relative;`;
         this.htmlObject.appendChild(this.contentPanel);
+
+        Object.assign(this.resizeOptions, {
+            minWidth,
+            minHeight,
+            ...(maxWidth ? { maxWidth } : {}),
+            ...(maxHeight ? { maxHeight } : {})
+        });
+        if (resizable) {
+            this.status.sizable = true;
+        }
     }
 
     #mkBtn(btnType) {

--- a/gridprj/tests/twindow.test.mjs
+++ b/gridprj/tests/twindow.test.mjs
@@ -15,6 +15,7 @@ const { Twindow } = await import('../files/js/src/ui/Twindow.js');
 document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
 const win = new Twindow();
+assert.strictEqual(win.status.sizable, true, 'window is resizable by default');
 win.showModal();
 assert.strictEqual(win.parent, DOM.baseLayer.subLayers.modal, 'placed in modal layer');
 win.hide();


### PR DESCRIPTION
## Summary
- dispatch `resizestart` and `resizeend` events for resizable elements
- make Twindow resizable and expose default `sizable` status

## Testing
- `node tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_688f3a7f31e883309de4e86de3e8bc43