### PR TITLE
Use resize start/end events in legacy prop editor

### DIFF
--- a/gridprj/files/js/src/ui/SplitBar.js
+++ b/gridprj/files/js/src/ui/SplitBar.js
@@ -1,0 +1,33 @@
+export class SplitBar {
+  constructor(direction = 'vertical', onStart, onDrag, onEnd) {
+    this.direction = direction;
+    this.htmlObject = document.createElement('div');
+    if (direction === 'vertical') {
+      this.htmlObject.style.cssText = 'cursor:col-resize;width:5px;position:absolute;min-width:5px;background-color:#999;height:100%;display:inline-block;overflow:hidden;vertical-align:top;';
+    } else {
+      this.htmlObject.style.cssText = 'cursor:row-resize;height:5px;position:absolute;min-height:5px;background-color:#999;width:100%;display:block;overflow:hidden;';
+    }
+    this.htmlObject.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      let lastX = e.clientX;
+      let lastY = e.clientY;
+      onStart?.(e);
+      const move = (ev) => {
+        const dx = ev.clientX - lastX;
+        const dy = ev.clientY - lastY;
+        lastX = ev.clientX;
+        lastY = ev.clientY;
+        onDrag?.(ev, { dx, dy });
+      };
+      const stop = (ev) => {
+        document.removeEventListener('mousemove', move);
+        document.removeEventListener('mouseup', stop);
+        onEnd?.(ev);
+      };
+      document.addEventListener('mousemove', move);
+      document.addEventListener('mouseup', stop);
+    });
+  }
+}
+
+window.SplitBar = SplitBar;

--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -4,6 +4,7 @@ import { Ealign, Tord } from '../../core/enums.js';
 import { onDOMLoad } from '../../core/loader.js';
 import { Tcolor, calculateLuminance } from '../../utils/colorUtils.js';
 import { cssProps } from '../../data/cssProperties.js';
+import { SplitBar } from '../SplitBar.js';
 import '../../core/prototypes.js';
 
 // Renk tanımları cssProps'tan oluşturuluyor
@@ -242,7 +243,7 @@ export class TpropEditor extends Twindow {
     super({ title: 'propeditor', width, height });
 this.status.sizable = true;
 
-    var cv, sp, cp, i, z, mx, mc;
+    var cv, sp, cp, i, z, mc;
     editbox = editbox ? editbox : new Teditbox('Code editor', 400, 400);
     this.cntx = document.createElement('div');
     this.cntx.innerHTML = '<div style=""></div>';
@@ -400,33 +401,26 @@ this.status.sizable = true;
 
     cp.innerHTML = '<table cellpadding=0 cellspacing=0 style="table-layout:fixed;min-width:100%;border-collapse:collapse;" id="tprops"></table>';
 
-    sp = document.createElement('div');
-    sp.style.cssText = 'cursor:col-resize;width:5px;position:absolute;min-width:5px;background-color:#999;height: 100%;display:inline-block;overflow:hidden;vertical-align:top;';
-    sp.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      mx = e.clientX;
-      if (cv.getElementsByTagName('table')[0].rows.length > 100)
-        cv.getElementsByTagName('table')[0].style.display = 'none';
-      const move = (ev) => {
-        var w, t = ev.clientX - mx;
-        mx = ev.clientX;
+    const splitBar = new SplitBar(
+      'vertical',
+      () => {
+        this.htmlObject.dispatchEvent(new Event('resizestart'));
+      },
+      (ev, { dx }) => {
+        var w, t = dx;
         if (t != 0) {
-          w = parseInt(sp.previousSibling.style.width);
-          if (w + t >= 30 && (sp.nextSibling.offsetWidth - t) >= 30) {
-            sp.previousSibling.style.width = (w + t) + 'px';
-            sp.nextSibling.style.width = 'calc(100% - ' + (w + t + 7) + 'px)';
+          w = parseInt(splitBar.htmlObject.previousSibling.style.width);
+          if (w + t >= 30 && (splitBar.htmlObject.nextSibling.offsetWidth - t) >= 30) {
+            splitBar.htmlObject.previousSibling.style.width = (w + t) + 'px';
+            splitBar.htmlObject.nextSibling.style.width = 'calc(100% - ' + (w + t + 7) + 'px)';
           }
         }
-      };
-      const up = () => {
-        document.removeEventListener('mousemove', move);
-        document.removeEventListener('mouseup', up);
-        if (cv.getElementsByTagName('table')[0].style.display == 'none')
-          cv.getElementsByTagName('table')[0].style.display = '';
-      };
-      document.addEventListener('mousemove', move);
-      document.addEventListener('mouseup', up);
-    });
+      },
+      () => {
+        this.htmlObject.dispatchEvent(new Event('resizeend'));
+      }
+    );
+    sp = splitBar.htmlObject;
 
     cv = document.createElement('div');
 
@@ -452,13 +446,24 @@ this.status.sizable = true;
     this.cntx.lvl = 0;
     this.maxSubLVL = 3;
     this.findsubprops(this.defobj, null, null);
-    this.htmlObject.onresize = function (x, y, p) {
-      if (x && p && cv.getElementsByTagName('table')[0].rows.length > 100) {
+    this.htmlObject.onresizestart = () => {
+      if (cv.getElementsByTagName('table')[0].rows.length > 100)
         cv.getElementsByTagName('table')[0].style.display = 'none';
-      } else if (p == false && cv.getElementsByTagName('table')[0].style.display == 'none') {
-        cv.getElementsByTagName('table')[0].style.display = '';
-      }
     };
+    this.htmlObject.onresizeend = () => {
+      if (cv.getElementsByTagName('table')[0].style.display == 'none')
+        cv.getElementsByTagName('table')[0].style.display = '';
+    };
+    let winResizeTimer;
+    window.addEventListener('resize', () => {
+      if (!winResizeTimer)
+        this.htmlObject.dispatchEvent(new Event('resizestart'));
+      clearTimeout(winResizeTimer);
+      winResizeTimer = setTimeout(() => {
+        this.htmlObject.dispatchEvent(new Event('resizeend'));
+        winResizeTimer = null;
+      }, 100);
+    });
     this.htmlObject.onwheel = (e) => {
       var ho = this.htmlObject;
       if (e.currentTarget == ho)


### PR DESCRIPTION
## Summary
- refactor splitter into reusable `SplitBar` component
- hide heavy table while resizing the window using `resizestart`/`resizeend`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f3ecbc7208330929a70ecfcc22542