### PR TITLE
Invoke custom resize handlers before dispatch

### DIFF
--- a/gridprj/files/js/src/dom/dom.js
+++ b/gridprj/files/js/src/dom/dom.js
@@ -464,7 +464,9 @@ export const DOM = {
             INTERACTION_STATE.set(el, 'resizing');
 
             if (!("onresizestart" in el)) el.onresizestart = null;
-            el.dispatchEvent(new CustomEvent('resizestart'));
+            const rsEvent = new CustomEvent('resizestart');
+            if (typeof el.onresizestart === 'function') el.onresizestart(rsEvent);
+            el.dispatchEvent(rsEvent);
 
             const start = {
                 x: e.clientX, y: e.clientY,
@@ -505,7 +507,9 @@ export const DOM = {
                 el.removeEventListener('pointercancel', onUp);
                 el.releasePointerCapture?.(ev.pointerId);
                 if (!("onresizeend" in el)) el.onresizeend = null;
-                el.dispatchEvent(new CustomEvent('resizeend'));
+                const reEvent = new CustomEvent('resizeend');
+                if (typeof el.onresizeend === 'function') el.onresizeend(reEvent);
+                el.dispatchEvent(reEvent);
                 INTERACTION_STATE.delete(el);
             };
 
@@ -572,7 +576,9 @@ makeResizableWithHandles : function (el, flags) {
                 const dirKey = dir;
 
                 if (!("onresizestart" in el)) el.onresizestart = null;
-                el.dispatchEvent(new CustomEvent('resizestart'));
+                const rsEvent = new CustomEvent('resizestart');
+                if (typeof el.onresizestart === 'function') el.onresizestart(rsEvent);
+                el.dispatchEvent(rsEvent);
 
                 function onMove(ev) {
                     const dx = ev.clientX - startX, dy = ev.clientY - startY;
@@ -590,7 +596,9 @@ makeResizableWithHandles : function (el, flags) {
                 function onUp() {
                     document.removeEventListener('mousemove', onMove);
                     if (!("onresizeend" in el)) el.onresizeend = null;
-                    el.dispatchEvent(new CustomEvent('resizeend'));
+                    const reEvent = new CustomEvent('resizeend');
+                    if (typeof el.onresizeend === 'function') el.onresizeend(reEvent);
+                    el.dispatchEvent(reEvent);
                 }
                 document.addEventListener('mousemove', onMove);
                 document.addEventListener('mouseup', onUp, { once: true });
@@ -629,7 +637,9 @@ makeResizableWithHandles : function (el, flags) {
             if (!dir) return;
             e.preventDefault();
             if (!("onresizestart" in el)) el.onresizestart = null;
-            el.dispatchEvent(new CustomEvent('resizestart'));
+            const rsEvent = new CustomEvent('resizestart');
+            if (typeof el.onresizestart === 'function') el.onresizestart(rsEvent);
+            el.dispatchEvent(rsEvent);
             const start = { x: e.clientX, y: e.clientY, ...r };
 
             function onDrag(ev) {
@@ -651,7 +661,9 @@ makeResizableWithHandles : function (el, flags) {
             function onUp() {
                 document.removeEventListener('mousemove', onDrag);
                 if (!("onresizeend" in el)) el.onresizeend = null;
-                el.dispatchEvent(new CustomEvent('resizeend'));
+                const reEvent = new CustomEvent('resizeend');
+                if (typeof el.onresizeend === 'function') el.onresizeend(reEvent);
+                el.dispatchEvent(reEvent);
             }
             document.addEventListener('mousemove', onDrag);
             document.addEventListener('mouseup', onUp, { once: true });

--- a/gridprj/files/js/src/ui/TSplitBar.js
+++ b/gridprj/files/js/src/ui/TSplitBar.js
@@ -17,8 +17,9 @@ export class TSplitBar {
       let lastX = e.clientX;
       let lastY = e.clientY;
       this.onStartMove?.(e);
-      if (typeof this.htmlObject.onstartmove === 'function') this.htmlObject.onstartmove(e);
- this.htmlObject.dispatchEvent(new CustomEvent('startmove'));
+      const startEv = new CustomEvent('startmove');
+      if (typeof this.htmlObject.onstartmove === 'function') this.htmlObject.onstartmove(startEv);
+      this.htmlObject.dispatchEvent(startEv);
 
       const move = (ev) => {
         const dx = ev.clientX - lastX;
@@ -31,8 +32,9 @@ export class TSplitBar {
         document.removeEventListener('mousemove', move);
         document.removeEventListener('mouseup', stop);
         this.onEndMove?.(ev);
-        if (typeof this.htmlObject.onendmove === 'function') this.htmlObject.onendmove(ev);
-  this.htmlObject.dispatchEvent(new CustomEvent('endmove'));
+        const endEv = new CustomEvent('endmove');
+        if (typeof this.htmlObject.onendmove === 'function') this.htmlObject.onendmove(endEv);
+        this.htmlObject.dispatchEvent(endEv);
 
       };
       document.addEventListener('mousemove', move);

--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -403,10 +403,14 @@ this.status.sizable = true;
 
     const splitBar = new TSplitBar('vertical');
     splitBar.onStartMove = () => {
-    this.htmlObject.dispatchEvent(new CustomEvent('resizestart'));
+    const ev = new CustomEvent('resizestart');
+    if (typeof this.htmlObject.onresizestart === 'function') this.htmlObject.onresizestart(ev);
+    this.htmlObject.dispatchEvent(ev);
     };
     splitBar.onEndMove = () => {
-      this.htmlObject.dispatchEvent(new CustomEvent('resizeend'));
+      const ev = new CustomEvent('resizeend');
+      if (typeof this.htmlObject.onresizeend === 'function') this.htmlObject.onresizeend(ev);
+      this.htmlObject.dispatchEvent(ev);
 
     };
     sp = splitBar.htmlObject;


### PR DESCRIPTION
## Summary
- ensure onresizestart/onresizeend handlers run when dispatching resize events
- call split bar start/end handlers using custom event objects
- hook property editor split bar to custom resize events

## Testing
- `node tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f5b87c5508330aa12101b1479dd11