### PR TITLE
Fix caption cursor and enhance style editing

### DIFF
--- a/gridprj/files/js/src/ui/Twindow.js
+++ b/gridprj/files/js/src/ui/Twindow.js
@@ -39,7 +39,12 @@ const TframeMixin = class TframeMixin {
         if (showCaption) {
             this.captionBar = document.createElement('div');
             this.captionBar.className = 'twindow-caption';
-            this.captionBar.style.cssText = `display:flex;align-items:center;justify-content:space-between;background:linear-gradient(#ececec,#e3e8f2 90%);height:30px;padding:0 10px 0 12px;user-select:none;cursor:${movable && !parent ? 'move' : 'default'};font-weight:bold;border-bottom:1px solid #c5c5c5`;
+            this.captionBar.style.cssText = `display:flex;align-items:center;justify-content:space-between;background:linear-gradient(#ececec,#e3e8f2 90%);height:30px;padding:0 10px 0 12px;user-select:none;font-weight:bold;border-bottom:1px solid #c5c5c5`;
+            if (movable && !parent && !resizable) {
+                this.captionBar.style.cursor = 'move';
+            } else {
+                this.captionBar.style.cursor = 'inherit';
+            }
 
             const captionTitle = document.createElement('div');
             captionTitle.textContent = title;

--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -5,6 +5,7 @@ import { onDOMLoad } from '../../core/loader.js';
 import { Tcolor, calculateLuminance } from '../../utils/colorUtils.js';
 import { cssProps } from '../../data/cssProperties.js';
 import { TSplitBar } from '../TSplitBar.js';
+import { ControlFactory } from '../style-editor/ControlFactory.js';
 import '../../core/prototypes.js';
 
 // Renk tanımları cssProps'tan oluşturuluyor
@@ -602,18 +603,26 @@ this.status.sizable = true;
                 ns = booleditor.htmlObject;
               } else {
                 if (typeof obj[i] == 'string') {
-                  var s = new String();
-                  s = obj[i];
-                  var patt1 = /^#[abcdef0123456789]*/g;
-                  var m = s.match(patt1);
-                  if ((m != null && (m[0].length - 1) % 3 == 0) || i.search(/color/i) != -1) {
-                    var coloreditor = new TeditListEditor(obj, i, Tcolors);
-                    ns = coloreditor.htmlObject;
+                  if (obj.constructor.name === 'CSSStyleDeclaration' && cssProps.properties[i]) {
+                    const control = ControlFactory.createControl(i, obj.ownerElement || obj._element || obj, (val) => {
+                      obj[i] = val;
+                    });
+                    ns = control;
                     ns.style.width = '100%';
                   } else {
-                    var texteditor = new TtextEditor(obj, i);
-                    ns = texteditor.htmlObject;
-                    ns.style.width = '100%';
+                    var s = new String();
+                    s = obj[i];
+                    var patt1 = /^#[abcdef0123456789]*/g;
+                    var m = s.match(patt1);
+                    if ((m != null && (m[0].length - 1) % 3 == 0) || i.search(/color/i) != -1) {
+                      var coloreditor = new TeditListEditor(obj, i, Tcolors);
+                      ns = coloreditor.htmlObject;
+                      ns.style.width = '100%';
+                    } else {
+                      var texteditor = new TtextEditor(obj, i);
+                      ns = texteditor.htmlObject;
+                      ns.style.width = '100%';
+                    }
                   }
                 } else {
                   var texteditor = new TtextEditor(obj, i, true && typeof obj[i] == 'function');

--- a/gridprj/files/js/src/ui/style-editor/controls/TcolorControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcolorControl.js
@@ -1,7 +1,7 @@
 // Bu dosya, bir CSS özelliğini düzenlemek için akıllı UI kontrolleri oluşturan sınıfları içerir.
 // Her kontrol, özelliğin türüne göre (renk, sayı, bileşik değer vb.) özelleşmiştir.
 import { TbaseControl } from './TbaseControl.js';
-import { TsingleColorPicker } from '../../colorpicker/TsingleColorPicker.js';
+import { TtabbedColorPicker } from '../../colorpicker/TtabbedColorPicker.js';
 // Renk isimleri listesi için cssProps'u ekliyoruz.
 import { cssProps } from '../../../data/cssProperties.js';
 
@@ -37,15 +37,17 @@ export class TcolorControl extends TbaseControl {
         });
 
         colorBox.addEventListener('click', () => {
-            // Merkezi PickerManager'ı kullanarak TsingleColorPicker'ı açıyoruz.
-            TsingleColorPicker.pick(TsingleColorPicker, {
-                targetInput: textInput, // Picker'ı doğrudan input'a bağlıyoruz
+            const picker = TtabbedColorPicker.getInstance({
+                targetInput: textInput,
                 defaultColor: textInput.value,
                 onChange: (color) => {
                     colorBox.style.backgroundColor = color;
+                    textInput.value = color;
                     this.onChange(color);
                 }
             });
+            picker.popup(colorBox);
+            picker.show();
         });
 
         container.append(textInput, colorBox, dataList);


### PR DESCRIPTION
## Summary
- Avoid forcing a move cursor on resizable Twindow captions so resize handles show correctly
- Use tabbed color picker for style editor color fields, enabling single color and gradient selections
- Generate context-aware inputs in legacy prop editor using CSS metadata for color pickers and numeric unit selectors

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom --no-save` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_688f6f0e1004833086ada9052c39601b