### PR TITLE
fix: handle CSSStyleDeclaration in ControlFactory

### DIFF
--- a/gridprj/files/js/src/ui/style-editor/ControlFactory.js
+++ b/gridprj/files/js/src/ui/style-editor/ControlFactory.js
@@ -11,7 +11,7 @@ import { cssProps } from '../../data/cssProperties.js';
 export class ControlFactory {
     /**
      * @param {string} styleProp - Düzenlenecek CSS özelliği (örn: 'backgroundColor').
-     * @param {HTMLElement} targetElement - Stilin uygulanacağı hedef element.
+     * @param {HTMLElement|CSSStyleDeclaration} targetElement - Stilin uygulanacağı hedef element veya doğrudan stil deklarasyonu.
      * @param {Function} onChange - Değer değiştiğinde çağrılacak callback.
      * @returns {HTMLElement} Oluşturulan kontrolün ana HTML elementi.
      */
@@ -23,7 +23,7 @@ export class ControlFactory {
             return new TautoCompleteControl(styleProp, [], targetElement, onChange).render();
         }
 
-        const initialValue = targetElement.style[styleProp] || meta.initial;
+        const initialValue = (targetElement.style ? targetElement.style[styleProp] : targetElement[styleProp]) || meta.initial;
         const allValues = meta.values || [];
 
         // 1. Bileşik Değer Kontrolü (örn: border, animation)

--- a/gridprj/files/js/src/ui/style-editor/controls/TbaseControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TbaseControl.js
@@ -5,7 +5,7 @@ export  class TbaseControl {
         this.meta = meta;
         this.targetElement = targetElement;
         this.onChange = onChange;
-        this.initialValue = targetElement.style[styleProp] || meta?.initial || '';
+        this.initialValue = (targetElement.style ? targetElement.style[styleProp] : targetElement[styleProp]) || meta?.initial || '';
     }
     render() {
         throw new Error("Render metodu alt sınıfta tanımlanmalıdır.");


### PR DESCRIPTION
## Summary
- allow ControlFactory to accept CSSStyleDeclaration objects by checking for `.style` property
- initialize TbaseControl safely when passed a CSSStyleDeclaration

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f74bd9cdc83308946ccec41059868