### PR TITLE
Fix style property handling in property editor

### DIFF
--- a/gridprj/files/js/src/ui/prop-editor/TpropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TpropEditor.js
@@ -218,7 +218,12 @@ export class TpropEditor extends Twindow {
         rowsContainer.style.display = 'flex';
         rowsContainer.style.flexDirection = 'column';
 
-        for (const key in obj) {
+        // CSSStyleDeclaration nesneleri farklı şekilde ele alınır.
+        const keys = obj instanceof CSSStyleDeclaration
+            ? Array.from({ length: obj.length }, (_, i) => obj[i])
+            : Object.keys(obj);
+
+        for (const key of keys) {
             const row = document.createElement('div');
             row.className = 'prop-row';
             row.style.display = 'flex';
@@ -233,7 +238,9 @@ export class TpropEditor extends Twindow {
             valueCell.className = 'prop-value';
             valueCell.style.flex = '1';
 
-            const val = obj[key];
+            const val = obj instanceof CSSStyleDeclaration
+                ? obj.getPropertyValue(key)
+                : obj[key];
 
             // Özellik tipine göre renklendirme
             if (typeof val === 'object' && val !== null) {

--- a/gridprj/files/js/src/ui/prop-editor/editorRegistry.js
+++ b/gridprj/files/js/src/ui/prop-editor/editorRegistry.js
@@ -128,13 +128,17 @@ class TstylePropertyEditor extends TbaseEditor {
     render() {
         // parent: style nesnesi
         // parent.owner: stilin ait olduğu Telement
-        const targetElement = this.parent.owner?.htmlObject || null;
+        const targetElement = this.parent.owner?.htmlObject || this.parent.ownerElement || null;
         if (!targetElement) {
             return new TtextEditor(this.parent, this.key).render();
         }
 
         const onChangeCallback = (newValue) => {
-            this._updateValue(newValue);
+            if (typeof this.parent.setProperty === 'function') {
+                this.parent.setProperty(this.key, newValue);
+            } else {
+                this._updateValue(newValue);
+            }
         };
 
         // StyleEditor'ın akıllı fabrikasını çağırıyoruz.

--- a/gridprj/files/js/src/ui/style-editor/controls/TbaseControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TbaseControl.js
@@ -5,7 +5,19 @@ export  class TbaseControl {
         this.meta = meta;
         this.targetElement = targetElement;
         this.onChange = onChange;
-        this.initialValue = (targetElement.style ? targetElement.style[styleProp] : targetElement[styleProp]) || meta?.initial || '';
+
+        let init = '';
+        if (targetElement && targetElement.style) {
+            const styleObj = targetElement.style;
+            if (typeof styleObj.getPropertyValue === 'function') {
+                init = styleObj.getPropertyValue(styleProp);
+            } else {
+                init = styleObj[styleProp];
+            }
+        } else if (targetElement) {
+            init = targetElement[styleProp];
+        }
+        this.initialValue = init || meta?.initial || '';
     }
     render() {
         throw new Error("Render metodu alt sınıfta tanımlanmalıdır.");


### PR DESCRIPTION
## Summary
- enumerate CSS style declarations properly and fetch values via `getPropertyValue`
- wire style editor to underlying element using `setProperty` for accurate updates
- initialize base controls with CSS `getPropertyValue` for hyphenated properties

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f789112ec8330b7a26976b9ba69a9