### PR TITLE
Fix style property mapping and color control

### DIFF
--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -8,6 +8,12 @@ import { TSplitBar } from '../TSplitBar.js';
 import { ControlFactory } from '../style-editor/ControlFactory.js';
 import '../../core/prototypes.js';
 
+// CSSStyleDeclaration üzerinde dönen property isimleri genellikle
+// camelCase biçimindedir. cssProps verisi ise tireli (kebab-case)
+// anahtarlar içerir. Bu yardımcı fonksiyon, stil isimlerini doğru
+// formata çevirerek cssProps ile eşleşmeyi sağlar.
+const toKebabCase = (prop) => prop.replace(/([A-Z])/g, '-$1').toLowerCase();
+
 // Renk tanımları cssProps'tan oluşturuluyor
 export const Tcolors = cssProps.colorNames.reduce((acc, name) => {
   acc[name] = name;
@@ -603,12 +609,29 @@ this.status.sizable = true;
                 ns = booleditor.htmlObject;
               } else {
                 if (typeof obj[i] == 'string') {
-                  if (obj.constructor.name === 'CSSStyleDeclaration' && cssProps.properties[i]) {
-                    const control = ControlFactory.createControl(i, obj.ownerElement || obj._element || obj, (val) => {
-                      obj[i] = val;
-                    });
-                    ns = control;
-                    ns.style.width = '100%';
+                  if (obj.constructor.name === 'CSSStyleDeclaration') {
+                    const cssName = toKebabCase(i);
+                    if (cssProps.properties[cssName]) {
+                      const control = ControlFactory.createControl(cssName, obj.ownerElement || obj._element || obj, (val) => {
+                        obj[i] = val;
+                      });
+                      ns = control;
+                      ns.style.width = '100%';
+                    } else {
+                      var s = new String();
+                      s = obj[i];
+                      var patt1 = /^#[abcdef0123456789]*/g;
+                      var m = s.match(patt1);
+                      if ((m != null && (m[0].length - 1) % 3 == 0) || i.search(/color/i) != -1) {
+                        var coloreditor = new TeditListEditor(obj, i, Tcolors);
+                        ns = coloreditor.htmlObject;
+                        ns.style.width = '100%';
+                      } else {
+                        var texteditor = new TtextEditor(obj, i);
+                        ns = texteditor.htmlObject;
+                        ns.style.width = '100%';
+                      }
+                    }
                   } else {
                     var s = new String();
                     s = obj[i];

--- a/gridprj/files/js/src/ui/style-editor/ControlFactory.js
+++ b/gridprj/files/js/src/ui/style-editor/ControlFactory.js
@@ -23,7 +23,17 @@ export class ControlFactory {
             return new TautoCompleteControl(styleProp, [], targetElement, onChange).render();
         }
 
-        const initialValue = (targetElement.style ? targetElement.style[styleProp] : targetElement[styleProp]) || meta.initial;
+        let initialValue = '';
+        if (targetElement.style) {
+            if (typeof targetElement.style.getPropertyValue === 'function') {
+                initialValue = targetElement.style.getPropertyValue(styleProp);
+            } else {
+                initialValue = targetElement.style[styleProp];
+            }
+        } else if (targetElement[styleProp] !== undefined) {
+            initialValue = targetElement[styleProp];
+        }
+        initialValue = initialValue || meta.initial;
         const allValues = meta.values || [];
 
         // 1. Bileşik Değer Kontrolü (örn: border, animation)
@@ -33,7 +43,7 @@ export class ControlFactory {
 
         // 2. Renk Kontrolü
         if (allValues.includes('[color]')) {
-            return new TcolorControl(styleProp, initialValue, targetElement, onChange).render();
+            return new TcolorControl(styleProp, meta, targetElement, onChange).render();
         }
 
         // 3. Sayısal/Uzunluk Kontrolü

--- a/gridprj/files/js/src/ui/style-editor/StyleEditor.js
+++ b/gridprj/files/js/src/ui/style-editor/StyleEditor.js
@@ -66,7 +66,11 @@ export class StyleEditor {
 
         // Değer değiştiğinde hedef elementin stilini güncelleyecek olan callback fonksiyonu
         const onChangeCallback = (newValue) => {
-            this.targetElement.style[styleProp] = newValue;
+            if (typeof this.targetElement.style.setProperty === 'function') {
+                this.targetElement.style.setProperty(styleProp, newValue);
+            } else {
+                this.targetElement.style[styleProp] = newValue;
+            }
         };
 
         // Fabrikayı kullanarak doğru kontrolü oluştur
@@ -102,7 +106,11 @@ export class StyleEditor {
             const controlWrap = document.createElement('div');
             controlWrap.style.cssText = 'flex:1;';
             const control = ControlFactory.createControl(prop, this.targetElement, val => {
-                this.targetElement.style[prop] = val;
+                if (typeof this.targetElement.style.setProperty === 'function') {
+                    this.targetElement.style.setProperty(prop, val);
+                } else {
+                    this.targetElement.style[prop] = val;
+                }
             });
             controlWrap.appendChild(control);
 


### PR DESCRIPTION
## Summary
- Map camelCase CSSStyleDeclaration keys to kebab-case so metadata and controls resolve
- Improve ControlFactory to read/set hyphenated properties and use color control meta
- Use CSSStyleDeclaration.setProperty when updating styles from editors

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f8260f06083308e7bf48ddcb70b15