### PR TITLE
fix: keep prop names aligned with scroll

### DIFF
--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -404,7 +404,7 @@ this.status.sizable = true;
     cp = document.createElement('div');
 
     cp.className = 'prop-keys';
-    cp.style.cssText = 'display:inline-block;width:100px;height:100%;';
+    cp.style.cssText = 'display:inline-block;width:100px;height:100%;overflow:hidden;';
 
     cp.innerHTML = '<table cellpadding=0 cellspacing=0 style="table-layout:fixed;min-width:100%;border-collapse:collapse;" id="tprops"></table>';
 


### PR DESCRIPTION
## Summary
- ensure property name table hides overflow so keys stay aligned with values while scrolling

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom --no-save --no-package-lock` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f94ce65fc8330a14c6cf20e383f8f