### PR TITLE
Reset prop editor scroll after filtering

### DIFF
--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -407,6 +407,7 @@ this.status.sizable = true;
     cp.style.cssText = 'display:inline-block;width:100px;height:100%;overflow:hidden;';
 
     cp.innerHTML = '<table cellpadding=0 cellspacing=0 style="table-layout:fixed;min-width:100%;border-collapse:collapse;" id="tprops"></table>';
+    this.keysDiv = cp;
 
     const splitBar = new TSplitBar('vertical');
     splitBar.onStartMove = () => {
@@ -432,6 +433,7 @@ this.status.sizable = true;
     cv.onscroll = function (e) {
       cp.scrollTop = cv.scrollTop;
     };
+    this.valuesDiv = cv;
 
     this.cntx.appendChild(cp);
     this.cntx.appendChild(sp);
@@ -489,6 +491,10 @@ this.status.sizable = true;
         tp.rows[i].style.display = 'none';
         tv.rows[i].style.display = 'none';
       }
+    }
+    if (this.keysDiv && this.valuesDiv) {
+      this.keysDiv.scrollTop = 0;
+      this.valuesDiv.scrollTop = 0;
     }
   }
 
@@ -553,12 +559,14 @@ this.status.sizable = true;
           nr = tp.insertRow(k);
           nr1 = nr;
           nr = nr.insertCell();
-          np = tv.insertRow(k);
-          np = np.insertCell();
+
+          const npRow = tv.insertRow(k);
+          npRow.style.height = nr1.style.height = '18px';
+          np = npRow.insertCell();
           np.valign = 'center';
           np.style.cssText = nr.style.cssText;
           np = np.appendChild(document.createElement('div'));
-          np.style = 'height:100%;box-sizing: border-box';
+          np.style.cssText = 'height:100%;box-sizing:border-box;font-size:inherit;';
           k = k + 1;
           nr1.lvl = (lvl ? lvl + '-' : '') + k;
           if (obj[i] != null)


### PR DESCRIPTION
## Summary
- Keep references to key/value panels in `TlegacyPropEditor`
- Reset scroll positions after filtering to align left and right tables
- Standardize row heights so both panels stay in sync

## Testing
- `npm install jsdom --no-save` *(fails: 403 Forbidden)*
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_688f9705f84483308435ced5e891678f