### PR TITLE
Fix property editor row heights

### DIFF
--- a/gridprj/files/css/propeditor.css
+++ b/gridprj/files/css/propeditor.css
@@ -8,6 +8,16 @@
 .TpropEditor .propdiv{width: 100%; height: 18px;overflow: hidden;text-wrap: nowrap; font-size: small; font-family: monospace; font-weight: 700;user-select: none;display:flex;flex-direction: row;}
 .TpropEditor .propin{width: 100%;border: none;}
 .TpropEditor .propinput{width: 100%;box-sizing: border-box; font-size: small; font-family: monospace; font-weight: 700;}
+.TpropEditor input:not(._findbar),
+.TpropEditor select{
+    height:18px;
+    line-height:18px;
+    margin:0;
+    padding:0;
+    border:none;
+    box-sizing:border-box;
+    background:transparent;
+}
 .TpropEditor .propdiv span:hover{color:#0000CC;cursor:pointer;}
 .TpropEditor ._findbar {width:100%;height: 12px;font-size: 10px;border:1px solid;}
 .TpropEditor .dropdown-menu {

--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -57,7 +57,11 @@ export class TeditListEditor {
   createInputField() {
     const inputField = document.createElement('input');
     inputField.type = 'text';
-    inputField.style.cssText = 'width: 100%; font-size: inherit; border: 1px solid rgb(105, 152, 237); box-sizing: border-box;';
+    // Borders from the input field were inflating row height and
+    // breaking the synchronized scrolling between the keys and
+    // values tables.  Use a borderless input and lock the height so
+    // each row keeps a consistent size.
+    inputField.style.cssText = 'width:100%;height:100%;font-size:inherit;box-sizing:border-box;border:none;margin:0;padding:0;';
     inputField.value = this.object[this.property];
     inputField.onchange = () => {
       this.object[this.property] = inputField.value;
@@ -164,7 +168,9 @@ export function TtextEditor(bo, bp, pf) {
   var o, t = this;
   t.htmlObject = document.createElement('INPUT');
   o = t.htmlObject;
-  o.style.cssText = 'height:100%;width: calc(100% - 2px); font-size: inherit; border: 1px solid rgb(105, 152, 237);box-sizing: border-box;';
+  // Remove borders and enforce a fixed height so text editors do not
+  // expand rows beyond the grid's baseline height.
+  o.style.cssText = 'height:100%;width:100%;font-size:inherit;box-sizing:border-box;border:none;margin:0;padding:0;';
   function setText(value) {
     bo[bp] = value;
     if (o.value != bo[bp])

--- a/gridprj/files/js/src/ui/style-editor/controls/TcolorControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcolorControl.js
@@ -8,12 +8,15 @@ import { cssProps } from '../../../data/cssProperties.js';
 export class TcolorControl extends TbaseControl {
     render() {
         const container = document.createElement('div');
-        container.style.cssText = 'display: flex; align-items: center; gap: 5px;';
+        // Match the property editor's row height and avoid extra borders
+        // so that color controls do not stretch the table rows.
+        container.style.cssText = 'display:flex;align-items:center;gap:5px;height:100%;';
 
         const textInput = document.createElement('input');
         textInput.type = 'text';
         textInput.value = this.initialValue;
-        textInput.style.flex = '1';
+        // Remove default borders/padding and fit the row height
+        textInput.style.cssText = 'flex:1;height:100%;box-sizing:border-box;border:none;margin:0;padding:0;';
 
         // Hazır CSS renk isimlerini sunmak için datalist kullanıyoruz.
         const listId = `${this.styleProp}-colors-${Math.random().toString(36).slice(2)}`;
@@ -27,7 +30,8 @@ export class TcolorControl extends TbaseControl {
         });
         
         const colorBox = document.createElement('div');
-        colorBox.style.cssText = 'width: 28px; height: 28px; border: 1px solid #888; cursor: pointer;';
+        // Use a compact swatch that aligns with the editor row size
+        colorBox.style.cssText = 'width:18px;height:18px;cursor:pointer;';
         colorBox.style.backgroundColor = this.initialValue;
 
         // İki yönlü veri bağlama


### PR DESCRIPTION
## Summary
- Ensure property editor rows keep a constant height by removing input borders and locking control dimensions
- Shrink color picker control and sync its size with table rows
- Apply global CSS to enforce 18px height for inputs and selects in the editor

## Testing
- `node tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f9e00440c8330aa65c0728c0e5f42