### PR TITLE
Improve style editor controls

### DIFF
--- a/gridprj/files/js/src/ui/style-editor/controls/TcolorControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcolorControl.js
@@ -10,13 +10,13 @@ export class TcolorControl extends TbaseControl {
         const container = document.createElement('div');
         // Match the property editor's row height and avoid extra borders
         // so that color controls do not stretch the table rows.
-        container.style.cssText = 'display:flex;align-items:center;gap:5px;height:100%;';
+        container.style.cssText = 'display:flex;align-items:center;height:100%;';
 
         const textInput = document.createElement('input');
         textInput.type = 'text';
         textInput.value = this.initialValue;
         // Remove default borders/padding and fit the row height
-        textInput.style.cssText = 'flex:1;height:100%;box-sizing:border-box;border:none;margin:0;padding:0;';
+        textInput.style.cssText = 'flex:1;height:100%;box-sizing:border-box;border:none;margin:0;padding:0;border-right:1px solid #ccc;';
 
         // Hazır CSS renk isimlerini sunmak için datalist kullanıyoruz.
         const listId = `${this.styleProp}-colors-${Math.random().toString(36).slice(2)}`;
@@ -31,7 +31,7 @@ export class TcolorControl extends TbaseControl {
         
         const colorBox = document.createElement('div');
         // Use a compact swatch that aligns with the editor row size
-        colorBox.style.cssText = 'width:18px;height:18px;cursor:pointer;';
+        colorBox.style.cssText = 'width:18px;height:18px;cursor:pointer;box-sizing:border-box;border:1px solid #ccc;';
         colorBox.style.backgroundColor = this.initialValue;
 
         // İki yönlü veri bağlama
@@ -50,8 +50,7 @@ export class TcolorControl extends TbaseControl {
                     this.onChange(color);
                 }
             });
-            picker.popup(colorBox);
-            picker.show();
+            picker.showModal();
         });
 
         container.append(textInput, colorBox, dataList);

--- a/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
@@ -21,11 +21,11 @@ export class TcompoundValueControl extends TbaseControl {
         });
         container.appendChild(suggestionBox);
 
-        const orderedProps = [];
+        const expectedTokens = [];
         const staticOptions = [];
         (this.meta.values || []).forEach(tok => {
             if (tok.startsWith('[prop:')) {
-                orderedProps.push(tok.slice(6, -1));
+                expectedTokens.push(tok.slice(6, -1));
             } else if (tok === 'initial' || tok === 'inherit') {
                 staticOptions.push(tok);
             }
@@ -34,38 +34,34 @@ export class TcompoundValueControl extends TbaseControl {
         const dynamicTokens = ['[length]','[percent]','[time]','[number]','[string]'];
 
         const getSuggestions = () => {
-            const text = input.value;
-            const tokens = text.trim() === '' ? [] : text.trim().split(/\s+/);
-            const editingIndex = text.endsWith(' ') ? tokens.length : tokens.length - 1;
-            const currentPart = text.endsWith(' ') ? '' : (tokens[editingIndex] || '');
+            const val = input.value;
+            const tokens = val.split(/\s+/);
+            if (val.endsWith(' ')) tokens.push('');
+            const current = tokens[tokens.length - 1].toLowerCase();
             const suggestions = new Set();
 
-            if (editingIndex === 0) {
-                staticOptions.forEach(opt => suggestions.add(opt));
-            }
-
-            if (editingIndex >= 0 && editingIndex < orderedProps.length) {
-                const subProp = orderedProps[editingIndex];
+            expectedTokens.forEach(subProp => {
                 const subMeta = cssProps.properties[subProp];
-                if (subMeta) {
-                    (subMeta.values || []).forEach(val => {
-                        if (dynamicTokens.includes(val)) return;
-                        if (val === '[color]') {
-                            (cssProps.colorNames || []).forEach(c => suggestions.add(c));
-                        } else if (val === '[family-name]') {
-                            (cssProps.familyNames || []).forEach(f => suggestions.add(f));
-                        } else if (val === '[generic-family]') {
-                            (cssProps.genericFamilies || []).forEach(g => suggestions.add(g));
-                        } else if (val.startsWith('[fn:')) {
-                            suggestions.add(val);
-                        } else if (!val.startsWith('[')) {
-                            suggestions.add(val);
-                        }
-                    });
-                }
-            }
+                if (!subMeta) return;
+                (subMeta.values || []).forEach(v => {
+                    if (dynamicTokens.includes(v)) return;
+                    if (v === '[color]') {
+                        (cssProps.colorNames || []).forEach(c => suggestions.add(c));
+                    } else if (v === '[family-name]') {
+                        (cssProps.familyNames || []).forEach(f => suggestions.add(f));
+                    } else if (v === '[generic-family]') {
+                        (cssProps.genericFamilies || []).forEach(g => suggestions.add(g));
+                    } else if (v.startsWith('[fn:')) {
+                        suggestions.add(v.slice(4, -1) + '()');
+                    } else if (!v.startsWith('[')) {
+                        suggestions.add(v);
+                    }
+                });
+            });
 
-            return Array.from(suggestions).filter(s => s.toLowerCase().startsWith(currentPart.toLowerCase()));
+            staticOptions.forEach(opt => suggestions.add(opt));
+
+            return Array.from(suggestions).filter(s => s.toLowerCase().startsWith(current));
         };
 
         const updateSuggestions = () => {
@@ -87,13 +83,9 @@ export class TcompoundValueControl extends TbaseControl {
                     const text = input.value;
                     const tokens = text.trim() === '' ? [] : text.trim().split(/\s+/);
                     const editingIndex = text.endsWith(' ') ? tokens.length : tokens.length - 1;
-                    const replacement = sugg.startsWith('[fn:') && sugg.endsWith(']')
-                        ? sugg.slice(4, -1) + '()'
-                        : sugg;
-                    tokens[editingIndex] = replacement;
+                    tokens[editingIndex] = sugg;
                     let newValue = tokens.join(' ');
-                    const isStatic = staticOptions.includes(sugg);
-                    if (!isStatic && editingIndex < orderedProps.length - 1) {
+                    if (!staticOptions.includes(sugg)) {
                         newValue += ' ';
                     }
                     input.value = newValue;

--- a/gridprj/files/js/src/ui/style-editor/controls/TnumericControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TnumericControl.js
@@ -5,12 +5,14 @@ export class TnumericControl extends TbaseControl {
      render() {
         const container = document.createElement("div");
         container.style.display = 'flex';
+        container.style.height = '100%';
         const numInput = document.createElement("input");
         numInput.type = "number";
-        numInput.style.flex = '2';
-        
+        numInput.style.cssText = 'flex:1;height:100%;box-sizing:border-box;border:none;margin:0;padding:0;border-right:1px solid #ccc;';
+
         const unitSelect = document.createElement("select");
-        unitSelect.style.flex = '1';
+        unitSelect.style.cssText = 'width:40px;height:100%;box-sizing:border-box;border:none;margin:0;padding:0;';
+        unitSelect.style.flex = '0 0 40px';
         const units = this.getAvailableUnits();
         units.forEach(unit => {
             const opt = document.createElement("option");


### PR DESCRIPTION
## Summary
- Fix numeric control layout with vertical separator and fixed unit width
- Show color picker modally and add separators for multi-control rows
- Support order-agnostic compound CSS values in style editor

## Testing
- `node tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fa37b8174833096e11c8bcd7065db