### PR TITLE
refactor suggestion boxes to use layer system

### DIFF
--- a/gridprj/files/js/src/ui/colorpicker/TbaseColorPicker.js
+++ b/gridprj/files/js/src/ui/colorpicker/TbaseColorPicker.js
@@ -4,6 +4,7 @@ import { TabsoluteElement } from '../../dom/TabsoluteElement.js';
 import { Ealign } from '../../core/enums.js';
 import { getContrastColor, translayer, colorNameToHex } from './utils.js';
 import { cssProps } from '../../data/cssProperties.js';
+import { DOM } from '../../dom/dom.js';
 
 export class TbaseColorPicker extends TbasePicker {
 
@@ -44,10 +45,11 @@ export class TbaseColorPicker extends TbasePicker {
         this.suggestionBox = new TabsoluteElement({
             targetElement: this.hexInput,
             align: Ealign.bottom | Ealign.left | Ealign.right,
+            parent: DOM.baseLayer.subLayers.dropdown,
             className: 'cp-suggestions',
-            style: { fontSize: '10px', background: '#fff', border: '1px solid #ccc', maxHeight: '100px', overflowY: 'auto', width: '120px', zIndex: '1000' }
+            style: { fontSize: '10px', background: '#fff', border: '1px solid #ccc', maxHeight: '100px', overflowY: 'auto', width: '120px' }
         });
-        this.appendChild(this.suggestionBox);
+        this.suggestionBox.hide();
 
         this._wireSVEvents();
         this._wireHexRgbaEvents();

--- a/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
@@ -1,5 +1,8 @@
 import { TbaseControl } from './TbaseControl.js';
 import { cssProps } from '../../../data/cssProperties.js';
+import { TabsoluteElement } from '../../../dom/TabsoluteElement.js';
+import { Ealign } from '../../../core/enums.js';
+import { DOM } from '../../../dom/dom.js';
 
 export class TcompoundValueControl extends TbaseControl {
     render() {
@@ -12,14 +15,20 @@ export class TcompoundValueControl extends TbaseControl {
         input.placeholder = this.meta.syntax || 'Değerleri boşlukla ayırarak girin...';
         container.appendChild(input);
 
-        const suggestionBox = document.createElement('div');
-        suggestionBox.className = 'suggestion-box';
-        Object.assign(suggestionBox.style, {
-            position: 'absolute', top: '100%', left: 0, width: '100%',
-            border: '1px solid #ccc', background: '#fff', maxHeight: '150px',
-            overflowY: 'auto', zIndex: '1000', display: 'none', boxSizing: 'border-box'
+        const suggestionBox = new TabsoluteElement({
+            targetElement: input,
+            align: Ealign.bottom | Ealign.left | Ealign.right,
+            parent: DOM.baseLayer.subLayers.dropdown,
+            className: 'suggestion-box',
+            style: {
+                border: '1px solid #ccc',
+                background: '#fff',
+                maxHeight: '150px',
+                overflowY: 'auto',
+                boxSizing: 'border-box'
+            }
         });
-        container.appendChild(suggestionBox);
+        suggestionBox.hide();
 
         const expectedTokens = [];
         const staticOptions = [];
@@ -66,9 +75,9 @@ export class TcompoundValueControl extends TbaseControl {
 
         const updateSuggestions = () => {
             const suggestions = getSuggestions();
-            suggestionBox.innerHTML = '';
+            suggestionBox.htmlObject.innerHTML = '';
             if (suggestions.length === 0) {
-                suggestionBox.style.display = 'none';
+                suggestionBox.hide();
                 return;
             }
             suggestions.forEach(sugg => {
@@ -89,18 +98,19 @@ export class TcompoundValueControl extends TbaseControl {
                         newValue += ' ';
                     }
                     input.value = newValue;
-                    suggestionBox.style.display = 'none';
+                    suggestionBox.hide();
                     input.focus();
                     this.onChange(input.value.trim());
                 });
                 suggestionBox.appendChild(item);
             });
-            suggestionBox.style.display = 'block';
+            suggestionBox.htmlObject.style.width = `${input.offsetWidth}px`;
+            suggestionBox.popup();
         };
 
         input.addEventListener('input', updateSuggestions);
         input.addEventListener('change', () => this.onChange(input.value.trim()));
-        input.addEventListener('blur', () => setTimeout(() => suggestionBox.style.display = 'none', 200));
+        input.addEventListener('blur', () => setTimeout(() => suggestionBox.hide(), 200));
 
         return container;
     }


### PR DESCRIPTION
## Summary
- refactor style editor suggestion boxes to use layer-based TabsoluteElement, removing z-index
- adjust color picker suggestions to live in dropdown layer without z-index

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_688fae0e54a4833093a173da768372ff