### PR TITLE
fix suggestion box alignment in style control

### DIFF
--- a/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
@@ -6,7 +6,6 @@ import { DOM } from '../../../dom/dom.js';
 
 let sharedSuggestionBox;
 
-
 export class TcompoundValueControl extends TbaseControl {
     render() {
         const container = document.createElement('div');
@@ -18,21 +17,25 @@ export class TcompoundValueControl extends TbaseControl {
         input.placeholder = this.meta.syntax || 'Değerleri boşlukla ayırarak girin...';
         container.appendChild(input);
 
-        const suggestionBox = new TabsoluteElement({
-            targetElement: input,
-            align: Ealign.bottom | Ealign.left | Ealign.right,
-            parent: DOM.baseLayer.subLayers.dropdown,
-            className: 'suggestion-box',
-            style: {
-                border: '1px solid #ccc',
-                background: '#fff',
-                maxHeight: '150px',
-                overflowY: 'auto',
-                boxSizing: 'border-box'
+        const getSuggestionBox = () => {
+            if (!sharedSuggestionBox) {
+                sharedSuggestionBox = new TabsoluteElement({
+                    align: Ealign.bottom | Ealign.left | Ealign.right,
+                    parent: DOM.baseLayer.subLayers.dropdown,
+                    className: 'suggestion-box',
+                    style: {
+                        border: '1px solid #ccc',
+                        background: '#fff',
+                        maxHeight: '150px',
+                        overflowY: 'auto',
+                        boxSizing: 'border-box'
+                    }
+                });
+                sharedSuggestionBox.hide();
             }
-        });
-        suggestionBox.hide();
-
+            sharedSuggestionBox.targetElement = input;
+            return sharedSuggestionBox;
+        };
 
         const expectedTokens = [];
         const staticOptions = [];
@@ -104,22 +107,19 @@ export class TcompoundValueControl extends TbaseControl {
                         newValue += ' ';
                     }
                     input.value = newValue;
-             box.hide();
+                    box.hide();
 
                     input.focus();
                     this.onChange(input.value.trim());
                 });
                 box.appendChild(item);
             });
-    box.htmlObject.style.width = `${input.offsetWidth}px`;
             box.popup();
         };
 
         input.addEventListener('input', updateSuggestions);
         input.addEventListener('change', () => this.onChange(input.value.trim()));
         input.addEventListener('blur', () => setTimeout(() => sharedSuggestionBox?.hide(), 200));
-EventListener('blur', () => setTimeout(() => suggestionBox.hide(), 200));
-
 
         return container;
     }


### PR DESCRIPTION
## Summary
- reuse a shared suggestion box for compound style controls
- ensure popup targets the active input and aligns correctly

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_688fb9ced3f0833093ce2b7197a0d157