### PR TITLE
Ensure compound value suggestions use popup layer

### DIFF
--- a/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
@@ -9,7 +9,6 @@ let sharedSuggestionBox;
 export class TcompoundValueControl extends TbaseControl {
     render() {
         const container = document.createElement('div');
-        container.style.position = 'relative';
 
         const input = document.createElement('input');
         input.type = 'text';
@@ -21,8 +20,8 @@ export class TcompoundValueControl extends TbaseControl {
             if (!sharedSuggestionBox) {
                 sharedSuggestionBox = new TabsoluteElement({
                     align: Ealign.bottom | Ealign.left | Ealign.right,
-                    parent: DOM.baseLayer.subLayers.dropdown,
-                    className: 'suggestion-box',
+                    parent: DOM.baseLayer.subLayers.popup,
+                    className: 'suggestion-box popup absolute',
                     style: {
                         border: '1px solid #ccc',
                         background: '#fff',
@@ -114,6 +113,7 @@ export class TcompoundValueControl extends TbaseControl {
                 });
                 box.appendChild(item);
             });
+            box.htmlObject.style.width = input.getBoundingClientRect().width + 'px';
             box.popup();
         };
 


### PR DESCRIPTION
## Summary
- route compound value control suggestions through global popup layer for proper alignment
- size suggestion box to match the target input width

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom --no-save --no-package-lock` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fbd21400c8330be8cb0b78e67297c