### PR TITLE
Fix misaligned compound value suggestion popup

### DIFF
--- a/gridprj/files/js/src/dom/geometry.js
+++ b/gridprj/files/js/src/dom/geometry.js
@@ -410,13 +410,13 @@ this.y = y;
 return this.#push();
 }
 #applyChanges(changes) {
-const pp = TelementPoint.pagePos(this.#el);
+const parentPos = this.#el.offsetParent ? TelementPoint.pagePos(this.#el.offsetParent) : { x: 0, y: 0 };
 if (changes.left != null) {
-this.#el.style.left = `${changes.left - pp.x}px`;
+this.#el.style.left = `${changes.left - parentPos.x}px`;
 super.x = changes.left;
 }
 if (changes.top != null) {
-this.#el.style.top = `${changes.top - pp.y}px`;
+this.#el.style.top = `${changes.top - parentPos.y}px`;
 super.y = changes.top;
 }
 if (changes.width != null) {

--- a/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
@@ -9,7 +9,6 @@ let sharedSuggestionBox;
 export class TcompoundValueControl extends TbaseControl {
     render() {
         const container = document.createElement('div');
-        container.style.position = 'relative';
 
         const input = document.createElement('input');
         input.type = 'text';
@@ -20,9 +19,9 @@ export class TcompoundValueControl extends TbaseControl {
         const getSuggestionBox = () => {
             if (!sharedSuggestionBox) {
                 sharedSuggestionBox = new TabsoluteElement({
-                    align: Ealign.bottom | Ealign.left | Ealign.right,
+                    align: Ealign.bottom | Ealign.left | Ealign.right | Ealign.offset,
                     parent: DOM.baseLayer.subLayers.dropdown,
-                    className: 'suggestion-box',
+                    className: 'suggestion-box popup absolute',
                     style: {
                         border: '1px solid #ccc',
                         background: '#fff',
@@ -114,6 +113,8 @@ export class TcompoundValueControl extends TbaseControl {
                 });
                 box.appendChild(item);
             });
+            box.targetElement = input;
+            box.htmlObject.style.width = input.getBoundingClientRect().width + 'px';
             box.popup();
         };
 


### PR DESCRIPTION
## Summary
- compute absolute element positions relative to offset parents to fix repeated popup misalignment

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: Cannot find package 'jsdom')*
- `npm install jsdom --no-save --no-package-lock` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fbd21400c8330be8cb0b78e67297c