### PR TITLE
Prefix style editor classes with T and export globally

### DIFF
--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -5,7 +5,7 @@ import { onDOMLoad } from '../../core/loader.js';
 import { Tcolor, calculateLuminance } from '../../utils/colorUtils.js';
 import { cssProps } from '../../data/cssProperties.js';
 import { TSplitBar } from '../TSplitBar.js';
-import { ControlFactory } from '../style-editor/ControlFactory.js';
+import { TControlFactory } from '../style-editor/TControlFactory.js';
 import '../../core/prototypes.js';
 import { classToObjects } from '../../core/classUtils.js';
 import { Tlayer } from '../../dom/Tlayer.js';
@@ -736,7 +736,7 @@ this.status.sizable = true;
                   if (obj.constructor.name === 'CSSStyleDeclaration') {
                     const cssName = toKebabCase(i);
                     if (cssProps.properties[cssName]) {
-                      const control = ControlFactory.createControl(cssName, obj.ownerElement || obj._element || obj, (val) => {
+                      const control = TControlFactory.createControl(cssName, obj.ownerElement || obj._element || obj, (val) => {
                         obj[i] = val;
                       });
                       ns = control;

--- a/gridprj/files/js/src/ui/prop-editor/editorRegistry.js
+++ b/gridprj/files/js/src/ui/prop-editor/editorRegistry.js
@@ -1,7 +1,7 @@
 import { TsingleColorPicker } from '../colorpicker/TsingleColorPicker.js';
 import { Tord } from '../../core/enums.js';
 // StyleEditor'ın akıllı kontrol fabrikasını import ediyoruz.
-import { ControlFactory } from '../style-editor/ControlFactory.js';
+import { TControlFactory } from '../style-editor/TControlFactory.js';
 import { cssProps } from '../../data/cssProperties.js';
 
 // --- TEMEL EDİTÖR SINIFI ---
@@ -142,7 +142,7 @@ class TstylePropertyEditor extends TbaseEditor {
         };
 
         // StyleEditor'ın akıllı fabrikasını çağırıyoruz.
-        return ControlFactory.createControl(this.key, targetElement, onChangeCallback);
+        return TControlFactory.createControl(this.key, targetElement, onChangeCallback);
     }
 }
 

--- a/gridprj/files/js/src/ui/style-editor/TBoxModelPanel.js
+++ b/gridprj/files/js/src/ui/style-editor/TBoxModelPanel.js
@@ -1,9 +1,9 @@
-import { ControlFactory } from './ControlFactory.js';
+import { TControlFactory } from './TControlFactory.js';
 import { setStyleProperty, getStyleProperty } from './styleUtils.js';
 
 const sides = ['top', 'right', 'bottom', 'left'];
 
-export class BoxModelPanel {
+export class TBoxModelPanel {
     constructor(targetElement, container) {
         this.target = targetElement;
         this.container = container;
@@ -67,7 +67,7 @@ export class BoxModelPanel {
         const props = propMap[region];
         if (!props) return;
         props.forEach((prop, idx) => {
-            const ctrl = ControlFactory.createControl(prop, this.target, val => {
+            const ctrl = TControlFactory.createControl(prop, this.target, val => {
                 setStyleProperty(this.target.style, prop, val);
                 this.updateDiagram();
             });
@@ -114,5 +114,5 @@ export class BoxModelPanel {
     }
 }
 
-window.BoxModelPanel = BoxModelPanel;
+window.TBoxModelPanel = TBoxModelPanel;
 

--- a/gridprj/files/js/src/ui/style-editor/TControlFactory.js
+++ b/gridprj/files/js/src/ui/style-editor/TControlFactory.js
@@ -5,10 +5,10 @@ import { TcompoundValueControl } from './controls/TcompoundValueControl.js';
 import { cssProps } from '../../data/cssProperties.js';
 
 /**
- * ControlFactory: Bir CSS özelliğinin meta verisine bakarak
+ * TControlFactory: Bir CSS özelliğinin meta verisine bakarak
  * doğru UI kontrolünü (örn: renk seçici, sayısal giriş) oluşturan bir fabrika.
  */
-export class ControlFactory {
+export class TControlFactory {
     /**
      * @param {string} styleProp - Düzenlenecek CSS özelliği (örn: 'backgroundColor').
      * @param {HTMLElement|CSSStyleDeclaration} targetElement - Stilin uygulanacağı hedef element veya doğrudan stil deklarasyonu.
@@ -55,3 +55,5 @@ export class ControlFactory {
         return new TautoCompleteControl(styleProp, allValues, targetElement, onChange).render();
     }
 }
+
+window.TControlFactory = TControlFactory;

--- a/gridprj/files/js/src/ui/style-editor/TStyleEditor.js
+++ b/gridprj/files/js/src/ui/style-editor/TStyleEditor.js
@@ -1,8 +1,8 @@
-import { ControlFactory } from './ControlFactory.js';
+import { TControlFactory } from './TControlFactory.js';
 import { cssProps } from '../../data/cssProperties.js';
-import { BoxModelPanel } from './BoxModelPanel.js';
+import { TBoxModelPanel } from './TBoxModelPanel.js';
 
-export class StyleEditor {
+export class TStyleEditor {
     /**
      * @param {HTMLElement} targetElement - Stilleri düzenlenecek hedef element.
      * @param {HTMLElement} editorContainer - Düzenleme arayüzünün yerleştirileceği konteyner.
@@ -75,7 +75,7 @@ export class StyleEditor {
         };
 
         // Fabrikayı kullanarak doğru kontrolü oluştur
-        const control = ControlFactory.createControl(styleProp, this.targetElement, onChangeCallback);
+        const control = TControlFactory.createControl(styleProp, this.targetElement, onChangeCallback);
         wrapper.appendChild(control);
 
         this.editorContainer.appendChild(wrapper);
@@ -106,7 +106,7 @@ export class StyleEditor {
 
             const controlWrap = document.createElement('div');
             controlWrap.style.cssText = 'flex:1;';
-            const control = ControlFactory.createControl(prop, this.targetElement, val => {
+            const control = TControlFactory.createControl(prop, this.targetElement, val => {
                 if (typeof this.targetElement.style.setProperty === 'function') {
                     this.targetElement.style.setProperty(prop, val);
                 } else {
@@ -202,7 +202,9 @@ export class StyleEditor {
      */
     renderBoxModel() {
         this.editorContainer.innerHTML = '';
-        this.boxModelPanel = new BoxModelPanel(this.targetElement, this.editorContainer);
+        this.boxModelPanel = new TBoxModelPanel(this.targetElement, this.editorContainer);
     }
 }
+
+window.TStyleEditor = TStyleEditor;
 

--- a/gridprj/grild/Cssprops.html
+++ b/gridprj/grild/Cssprops.html
@@ -3513,7 +3513,7 @@
   "Tomato", "Turquoise", "Violet", "Wheat", "White",
  "WhiteSmoke", "Yellow", "YellowGreen"
 ];
-class StyleEditor {
+class TStyleEditor {
       constructor(element, container) {
         this.element = element;
         this.container = container;
@@ -3982,7 +3982,8 @@ class StyleEditor {
         return container;
       }
     }
-  
+window.TStyleEditor = TStyleEditor;
+
     document.addEventListener("DOMContentLoaded", () => {
       const target = document.getElementById("target");
       const editorContainer = document.getElementById("editor");
@@ -3996,7 +3997,7 @@ class StyleEditor {
         propSelect.appendChild(option);
       });
   
-      const styleEditor = new StyleEditor(target, editorContainer);
+      const styleEditor = new TStyleEditor(target, editorContainer);
       loadButton.addEventListener("click", () => {
         const selectedProp = propSelect.value;
         styleEditor.change(selectedProp);

--- a/gridprj/grild/style-editor-demo.js
+++ b/gridprj/grild/style-editor-demo.js
@@ -1,11 +1,11 @@
 import '../files/js/src/main.js';
-import { StyleEditor } from '../files/js/src/ui/style-editor/StyleEditor.js';
+import { TStyleEditor } from '../files/js/src/ui/style-editor/TStyleEditor.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const target = document.getElementById('preview');
   const listContainer = document.getElementById('propList');
 
-  const editor = new StyleEditor(target, listContainer);
+  const editor = new TStyleEditor(target, listContainer);
   // Tüm bilinen özellikleri listele
   editor.renderAll();
 });

--- a/gridprj/grild/test3 copy 2.html
+++ b/gridprj/grild/test3 copy 2.html
@@ -3462,7 +3462,7 @@ function createElementWithAttributes(tag, attrs = {}, text) {
   
     /* Örnek JSON veri */
    
-    class StyleEditor {
+    class TStyleEditor {
       constructor(element, container) {
         this.element = element;
         this.container = container;
@@ -3662,7 +3662,8 @@ function createElementWithAttributes(tag, attrs = {}, text) {
         this.element.style[compositeProp] = compositeValue;
       }
     }
-  
+    window.TStyleEditor = TStyleEditor;
+
     // Kullanım:
     document.addEventListener("DOMContentLoaded", () => {
       const target = document.getElementById("target");
@@ -3679,7 +3680,7 @@ function createElementWithAttributes(tag, attrs = {}, text) {
       document.body.insertBefore(propSelect, editor);
       document.body.insertBefore(loadButton, editor);
   
-      const styleEditor = new StyleEditor(target, editor);
+      const styleEditor = new TStyleEditor(target, editor);
   
       loadButton.addEventListener("click", () => {
         const selectedProp = propSelect.value;

--- a/gridprj/grild/test3.html
+++ b/gridprj/grild/test3.html
@@ -3513,7 +3513,7 @@
   "Tomato", "Turquoise", "Violet", "Wheat", "White",
  "WhiteSmoke", "Yellow", "YellowGreen"
 ];
-class StyleEditor {
+class TStyleEditor {
       constructor(element, container) {
         this.element = element;
         this.container = container;
@@ -3982,7 +3982,8 @@ class StyleEditor {
         return container;
       }
     }
-  
+window.TStyleEditor = TStyleEditor;
+
     document.addEventListener("DOMContentLoaded", () => {
       const target = document.getElementById("target");
       const editorContainer = document.getElementById("editor");
@@ -3996,7 +3997,7 @@ class StyleEditor {
         propSelect.appendChild(option);
       });
   
-      const styleEditor = new StyleEditor(target, editorContainer);
+      const styleEditor = new TStyleEditor(target, editorContainer);
       loadButton.addEventListener("click", () => {
         const selectedProp = propSelect.value;
         styleEditor.change(selectedProp);

--- a/gridprj/tests/boxmodel-panel.test.mjs
+++ b/gridprj/tests/boxmodel-panel.test.mjs
@@ -4,8 +4,12 @@ import { JSDOM } from 'jsdom';
 const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost' });
 global.window = dom.window;
 global.document = dom.window.document;
+global.DOMRect = dom.window.DOMRect;
+global.location = dom.window.location;
+const { TpositionedElement } = await import('../files/js/src/dom/TpositionedElement.js');
+global.TpositionedElement = TpositionedElement;
 
-import { BoxModelPanel } from '../files/js/src/ui/style-editor/BoxModelPanel.js';
+const { TBoxModelPanel } = await import('../files/js/src/ui/style-editor/TBoxModelPanel.js');
 
 document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
@@ -14,7 +18,7 @@ document.body.appendChild(target);
 const container = document.createElement('div');
 document.body.appendChild(container);
 
-const panel = new BoxModelPanel(target, container);
+const panel = new TBoxModelPanel(target, container);
 panel.showControls('margin');
 
 // Simulate user changing top margin through numeric control


### PR DESCRIPTION
## Summary
- rename style editor classes to start with `T` and expose them on `window`
- update style editor demo and property editor imports for new class names
- adjust sample HTML files to use `TStyleEditor` and attach to `window`

## Testing
- `node tests/boxmodel-panel.test.mjs` *(fails: HTMLCanvasElement.prototype.getContext not implemented, canvas package missing)*

------
https://chatgpt.com/codex/tasks/task_e_68910e3243b08330a79db8b5e83bf920