### PR TITLE
Fix color picker target handling and add Twindow embedding

### DIFF
--- a/gridprj/files/js/src/ui/Twindow.js
+++ b/gridprj/files/js/src/ui/Twindow.js
@@ -264,6 +264,37 @@ export class Twindow extends extendsClass(TdialogMixin, TframeMixin, Tpositioned
         this.#ensurePlacement(['dialog', 'modal']);
         return this.#open(false, DOM.getHtmlElement(target), align, dx, dy);
     }
+
+    embed(parent = null) {
+        this._embedBackup = {
+            border: this.htmlObject.style.border,
+            boxShadow: this.htmlObject.style.boxShadow,
+            position: this.htmlObject.style.position,
+            captionDisplay: this.captionBar ? this.captionBar.style.display : ''
+        };
+        if (this.captionBar) this.captionBar.style.display = 'none';
+        Object.assign(this.htmlObject.style, {
+            border: 'none',
+            boxShadow: 'none',
+            position: 'relative'
+        });
+        if (parent) {
+            this.body(parent);
+        } else if (!this.parent) {
+            this.body();
+        }
+    }
+
+    unembed() {
+        if (!this._embedBackup) return;
+        if (this.captionBar) this.captionBar.style.display = this._embedBackup.captionDisplay;
+        Object.assign(this.htmlObject.style, {
+            border: this._embedBackup.border,
+            boxShadow: this._embedBackup.boxShadow,
+            position: this._embedBackup.position
+        });
+        this._embedBackup = null;
+    }
     
     hide(result) {
         super.hide();

--- a/gridprj/files/js/src/ui/colorpicker/TbaseColorPicker.js
+++ b/gridprj/files/js/src/ui/colorpicker/TbaseColorPicker.js
@@ -222,8 +222,8 @@ export class TbaseColorPicker extends TbasePicker {
         const rgbaStr = Tcolor.hsvaToRgba(this.hsva);
         translayer.setForeColor(rgbaStr, this.previewBox);
 
-        if (this.targetElement && this.targetStyle) {
-            this.targetElement.style[this.targetStyle] = rgbaStr;
+        if (this.styleTarget && this.targetStyle) {
+            this.styleTarget.style[this.targetStyle] = rgbaStr;
         }
         
         const rgb = Tcolor.hsvaToRgb(this.hsva);

--- a/gridprj/files/js/src/ui/colorpicker/TbaseGradientPicker.js
+++ b/gridprj/files/js/src/ui/colorpicker/TbaseGradientPicker.js
@@ -176,8 +176,8 @@ renderStopButtons() {
   updatePreview(){
     const css = this.toCss(this.selectedFunction);
     translayer.setForeColor(css, this.previewBox);
-    if(this.targetElement && this.targetStyle)
-      this.targetElement.style[this.targetStyle]=css;
+    if(this.styleTarget && this.targetStyle)
+      this.styleTarget.style[this.targetStyle]=css;
     if(this.targetInput) this.targetInput.value=css;
      this.#refreshSelectors();
     this.onChange(css);

--- a/gridprj/files/js/src/ui/colorpicker/TbasePicker.js
+++ b/gridprj/files/js/src/ui/colorpicker/TbasePicker.js
@@ -25,7 +25,7 @@ export function pickerWindowOpts(opts = {}) {
 export function colorWindowOpts(opts = {}) {
     return {
         targetElement: null,
-        targetStyle: 'backgroundColor',
+        targetStyle: null,
         targetInput: null,
         defaultColor: '#ff0000',
         onChange: null,
@@ -40,14 +40,18 @@ export function colorWindowOpts(opts = {}) {
 export class TbasePicker extends Twindow {
     constructor(opts = {}) {
         super({
-            width: 300, height: 220, sizable: false,
+            width: 300,
+            height: 220,
+            sizable: false,
             title: opts.title ?? 'Color Picker',
             buttons: [EcaptionButton.close],
             closeMode: 'hide',
             ...opts
         });
 
-        this.targetStyle = opts.targetStyle ?? 'background';
+        this.styleTarget = opts.targetElement ?? null;
+        this.targetElement = this.styleTarget;
+        this.targetStyle = opts.targetStyle ?? null;
         this.targetInput = opts.targetInput ?? null;
         this.onChange = typeof opts.onChange === 'function' ? opts.onChange : () => {};
         this.onClose = typeof opts.onClose === 'function' ? opts.onClose : () => {};
@@ -71,8 +75,16 @@ export class TbasePicker extends Twindow {
             } else if (opts.container && inst.parent !== opts.container) {
                 inst.body(opts.container);
             }
+            inst.styleTarget = inst.targetElement;
+            inst.targetElement = inst.styleTarget;
         }
         return inst;
+    }
+
+    popup(target = null, align = null, dx = 0, dy = 0) {
+        const st = this.styleTarget;
+        super.popup(target, align, dx, dy);
+        this.targetElement = st;
     }
    attach(input) {
         this.targetInput = input;

--- a/gridprj/files/js/src/ui/colorpicker/TgradientPicker.js
+++ b/gridprj/files/js/src/ui/colorpicker/TgradientPicker.js
@@ -14,8 +14,8 @@ export class TgradientPicker extends TbaseGradientPicker {
     static pick(opts = {}) {
         const p = this.getInstance(opts);
         if (opts.targetInput) p.attach(opts.targetInput);
-        if (opts.targetElement) p.targetElement = opts.targetElement;
-        
+        if (opts.targetElement) p.styleTarget = opts.targetElement;
+
         p.popup(opts.targetElement || opts.targetInput || null);
         p.show();
         return p;
@@ -23,7 +23,7 @@ export class TgradientPicker extends TbaseGradientPicker {
 
     constructor(opts = {}) {
         super({ title: "Gradyan Seçici", ...opts });
-        const detectedCss = (this.targetInput?.value) || (this.targetElement && getComputedStyle(this.targetElement)[this.targetStyle]) || opts.defaultCss;
+        const detectedCss = (this.targetInput?.value) || (this.styleTarget && getComputedStyle(this.styleTarget)[this.targetStyle]) || opts.defaultCss;
         this.set(detectedCss);
     }
     

--- a/gridprj/files/js/src/ui/colorpicker/TmultiRadialGradientPicker.js
+++ b/gridprj/files/js/src/ui/colorpicker/TmultiRadialGradientPicker.js
@@ -17,8 +17,8 @@ export class TmultiRadialGradientPicker extends TbasePicker {
     static pick(opts = {}) {
         const p = this.getInstance(opts);
         if (opts.targetInput) p.attach(opts.targetInput);
-        if (opts.targetElement) p.targetElement = opts.targetElement;
-        
+        if (opts.targetElement) p.styleTarget = opts.targetElement;
+
         p.popup(opts.targetElement || opts.targetInput || null);
         p.show();
         return p;
@@ -63,7 +63,7 @@ export class TmultiRadialGradientPicker extends TbasePicker {
     updatePreview() {
         const css = this.getGradientCSS();
         translayer.setForeColor(css, this.previewBox);
-        if (this.targetElement) this.targetElement.style[this.targetStyle] = css;
+        if (this.styleTarget) this.styleTarget.style[this.targetStyle] = css;
         this.onChange(css);
         this.updateLinerBar();
     }

--- a/gridprj/files/js/src/ui/colorpicker/TsingleColorPicker.js
+++ b/gridprj/files/js/src/ui/colorpicker/TsingleColorPicker.js
@@ -12,8 +12,9 @@ export class TsingleColorPicker extends TbaseColorPicker {
      */
     static getInstance(opts = {}) {
         const inst = super.getInstance(opts);
-        inst.targetElement = opts.targetElement ?? inst.targetElement ?? null;
         inst.targetInput = opts.targetInput ?? inst.targetInput ?? null;
+        inst.styleTarget = opts.targetElement ?? inst.styleTarget ?? null;
+        inst.targetElement = inst.styleTarget;
         inst.onChange = typeof opts.onChange === 'function' ? opts.onChange : inst.onChange;
         inst.onClose = typeof opts.onClose === 'function' ? opts.onClose : inst.onClose;
         if (opts.defaultColor) {
@@ -45,7 +46,7 @@ export class TsingleColorPicker extends TbaseColorPicker {
 
         const detected =
             (this.targetInput && this.targetInput.value) ||
-            (this.targetElement && getComputedStyle(this.targetElement)[this.targetStyle]) ||
+            (this.styleTarget && getComputedStyle(this.styleTarget)[this.targetStyle]) ||
             opts.defaultColor;
 
         this.set(detected);

--- a/gridprj/files/js/src/ui/colorpicker/TtabbedColorPicker.js
+++ b/gridprj/files/js/src/ui/colorpicker/TtabbedColorPicker.js
@@ -63,7 +63,7 @@ export class TtabbedColorPicker extends TbasePicker {
             onChange: (value) => {
                 // Herhangi bir alt picker'dan gelen değeri ana onChange'e iletiyoruz
                 this.onChange(value);
-                if (this.targetElement) this.targetElement.style[this.targetStyle] = value;
+                if (this.styleTarget) this.styleTarget.style[this.targetStyle] = value;
                 if (this.targetInput) this.targetInput.value = value;
             }
         };
@@ -72,12 +72,8 @@ export class TtabbedColorPicker extends TbasePicker {
         this.pickers.gradient = new TgradientPicker({ ...commonOptions, title: '' });
         this.pickers.multiRadial = new TmultiRadialGradientPicker({ ...commonOptions, title: '' });
 
-        // Oluşturulan picker'ları body'ye ekleyerek DOM'a dahil ediyoruz
         Object.values(this.pickers).forEach(picker => {
-            picker.body();
-            picker.htmlObject.style.position = 'relative'; // Gömülü mod için
-            picker.htmlObject.style.border = 'none';
-            picker.htmlObject.style.boxShadow = 'none';
+            picker.embed(this.pickerContainer);
             picker.htmlObject.style.width = '100%';
             picker.htmlObject.style.height = '100%';
         });


### PR DESCRIPTION
## Summary
- avoid altering document body when using color pickers by decoupling style target handling
- add Twindow.embed/unembed to toggle window borders and captions for embedded pickers
- use new embedding in tabbed color picker

## Testing
- `node tests/boxmodel-panel.test.mjs` *(fails: HTMLCanvasElement.getContext not implemented)*
- `node tests/twindow.test.mjs` *(fails: DOMRect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68911cd23cc883308d5b823ae2dd3340