### PR TITLE
feat: centralize suggestion box component

### DIFF
--- a/gridprj/files/js/src/ui/TsuggestionBox.js
+++ b/gridprj/files/js/src/ui/TsuggestionBox.js
@@ -1,0 +1,81 @@
+import { TabsoluteElement } from '../dom/TabsoluteElement.js';
+import { Ealign } from '../core/enums.js';
+import { DOM } from '../dom/dom.js';
+
+export class TsuggestionBox extends TabsoluteElement {
+    static #instance;
+
+    static getInstance() {
+        if (!TsuggestionBox.#instance) {
+            TsuggestionBox.#instance = new TsuggestionBox();
+        }
+        return TsuggestionBox.#instance;
+    }
+
+    constructor() {
+        if (TsuggestionBox.#instance) {
+            return TsuggestionBox.#instance;
+        }
+        super({
+            align: Ealign.bottom | Ealign.left | Ealign.right,
+            parent: DOM.baseLayer?.subLayers.dropdown || document.body,
+            className: 'suggestion-box',
+            style: {
+                border: '1px solid #ccc',
+                background: '#fff',
+                maxHeight: '150px',
+                overflowY: 'auto',
+                boxSizing: 'border-box'
+            }
+        });
+        this.hide();
+        this.items = [];
+        this.selectedIndex = -1;
+        TsuggestionBox.#instance = this;
+    }
+
+    showFor(input, suggestions, onSelect) {
+        if (!suggestions || suggestions.length === 0) {
+            this.hide();
+            return;
+        }
+        this.targetElement = input;
+        this.htmlObject.style.width = input.getBoundingClientRect().width + 'px';
+        this.update(suggestions, onSelect);
+        this.popup();
+    }
+
+    update(suggestions, onSelect) {
+        this.htmlObject.innerHTML = '';
+        this.items = suggestions;
+        this.selectedIndex = -1;
+        this.onSelect = onSelect;
+        suggestions.forEach((s, i) => {
+            const item = document.createElement('div');
+            item.className = 'suggestion-item';
+            item.textContent = s;
+            item.style.padding = '5px';
+            item.style.cursor = 'pointer';
+            item.addEventListener('mousedown', (e) => {
+                e.preventDefault();
+                this.onSelect?.(s);
+                this.hide();
+            });
+            this.htmlObject.appendChild(item);
+        });
+    }
+
+    moveSelection(step) {
+        if (!this.items.length) return;
+        this.selectedIndex = (this.selectedIndex + step + this.items.length) % this.items.length;
+        Array.from(this.htmlObject.children).forEach((el, idx) => {
+            el.style.background = idx === this.selectedIndex ? '#bde4ff' : '';
+        });
+    }
+
+    getSelected() {
+        return this.items[this.selectedIndex] ?? null;
+    }
+}
+
+window.TsuggestionBox = TsuggestionBox;

--- a/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TcompoundValueControl.js
@@ -1,9 +1,5 @@
 import { cssProps } from '../../../data/cssProperties.js';
-import { TabsoluteElement } from '../../../dom/TabsoluteElement.js';
-import { Ealign } from '../../../core/enums.js';
-import { DOM } from '../../../dom/dom.js';
-
-let sharedSuggestionBox;
+import { TsuggestionBox } from '../../TsuggestionBox.js';
 
 export class TcompoundValueControl extends TbaseControl {
     render() {
@@ -16,26 +12,7 @@ export class TcompoundValueControl extends TbaseControl {
         input.placeholder = this.meta.syntax || 'Değerleri boşlukla ayırarak girin...';
         container.appendChild(input);
 
-        const getSuggestionBox = () => {
-            if (!sharedSuggestionBox) {
-                sharedSuggestionBox = new TabsoluteElement({
-                    align: Ealign.bottom | Ealign.left | Ealign.right,
-                    parent: DOM.baseLayer.subLayers.dropdown,
-                    className: 'suggestion-box',
-                    style: {
-                        border: '1px solid #ccc',
-                        background: '#fff',
-                        maxHeight: '150px',
-                        overflowY: 'auto',
-                        boxSizing: 'border-box'
-                    }
-                });
-                sharedSuggestionBox.hide();
-            }
-            sharedSuggestionBox.targetElement = input;
-            return sharedSuggestionBox;
-        };
-
+        const suggestionBox = TsuggestionBox.getInstance();
 
         const expectedTokens = [];
         const staticOptions = [];
@@ -80,48 +57,45 @@ export class TcompoundValueControl extends TbaseControl {
             return Array.from(suggestions).filter(s => s.toLowerCase().startsWith(current));
         };
 
- const updateSuggestions = () => {
-            const box = getSuggestionBox();
-            const suggestions = getSuggestions();
-            box.htmlObject.innerHTML = '';
-            if (suggestions.length === 0) {
-                box.hide();
-
-                return;
+        const applySuggestion = (sugg) => {
+            const text = input.value;
+            const tokens = text.trim() === '' ? [] : text.trim().split(/\s+/);
+            const editingIndex = text.endsWith(' ') ? tokens.length : tokens.length - 1;
+            tokens[editingIndex] = sugg;
+            let newValue = tokens.join(' ');
+            if (!staticOptions.includes(sugg)) {
+                newValue += ' ';
             }
+            input.value = newValue;
+            suggestionBox.hide();
+            input.focus();
+            this.onChange(input.value.trim());
+        };
 
-            suggestions.forEach(sugg => {
-                const item = document.createElement('div');
-                item.className = 'suggestion-item';
-                item.textContent = sugg;
-                item.style.padding = '5px';
-                item.style.cursor = 'pointer';
-
-                item.addEventListener('mousedown', e => {
-                    e.preventDefault();
-                    const text = input.value;
-                    const tokens = text.trim() === '' ? [] : text.trim().split(/\s+/);
-                    const editingIndex = text.endsWith(' ') ? tokens.length : tokens.length - 1;
-                    tokens[editingIndex] = sugg;
-                    let newValue = tokens.join(' ');
-                    if (!staticOptions.includes(sugg)) {
-                        newValue += ' ';
-                    }
-                    input.value = newValue;
-                    box.hide();
-
-                    input.focus();
-                    this.onChange(input.value.trim());
-                });
-                box.appendChild(item);
-            });
-            box.htmlObject.style.width = input.getBoundingClientRect().width + 'px';
-            box.popup();
+        const updateSuggestions = () => {
+            const suggestions = getSuggestions();
+            suggestionBox.showFor(input, suggestions, applySuggestion);
         };
 
         input.addEventListener('input', updateSuggestions);
+        input.addEventListener('keydown', e => {
+            if (!suggestionBox.status.visible) return;
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                suggestionBox.moveSelection(1);
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                suggestionBox.moveSelection(-1);
+            } else if (e.key === 'Enter') {
+                const sel = suggestionBox.getSelected();
+                if (sel) {
+                    e.preventDefault();
+                    applySuggestion(sel);
+                }
+            }
+        });
         input.addEventListener('change', () => this.onChange(input.value.trim()));
-        input.addEventListener('blur', () => setTimeout(() => sharedSuggestionBox?.hide(), 200));
+        input.addEventListener('blur', () => setTimeout(() => suggestionBox.hide(), 200));
 
         return container;
     }


### PR DESCRIPTION
## Summary
- add singleton `TsuggestionBox` for popup suggestions with keyboard navigation
- refactor `TcompoundValueControl` to use shared suggestion box and keyboard selection

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: DOMRect is not defined)*
- `node tests/boxmodel-panel.test.mjs` *(fails: HTMLCanvasElement.prototype.getContext not implemented)*


------
https://chatgpt.com/codex/tasks/task_e_6891c305baa4833099134840eb8e2750