### PR TITLE
Add example for testing TsuggestionBox positioning

### DIFF
--- a/gridprj/tests/suggestion-box-position.html
+++ b/gridprj/tests/suggestion-box-position.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>TsuggestionBox positioning demo</title>
+<style>
+  .scroll-box {
+    overflow: auto;
+    height: 120px;
+    border: 1px solid #ccc;
+    padding: 8px;
+    margin-bottom: 20px;
+  }
+  .inner-box {
+    height: 200px;
+    overflow: auto;
+    padding: 8px;
+  }
+</style>
+</head>
+<body>
+<script type="module">
+import { DOM } from '../files/js/src/dom/dom.js';
+import { Twindow } from '../files/js/src/ui/Twindow.js';
+import { TsuggestionBox } from '../files/js/src/ui/TsuggestionBox.js';
+
+// initialize DOM helpers
+window.addEventListener('DOMContentLoaded', () => {
+  // Example 1: input inside a Twindow with nested scrollable parents
+  const win = new Twindow();
+  win.showDialog();
+
+  const outer = document.createElement('div');
+  outer.className = 'scroll-box';
+  const inner = document.createElement('div');
+  inner.className = 'inner-box';
+  const input1 = document.createElement('input');
+  inner.appendChild(input1);
+  outer.appendChild(inner);
+  win.contentPanel.appendChild(outer);
+
+  // Example 2: input directly in body with scrollable parents
+  const outerBody = document.createElement('div');
+  outerBody.className = 'scroll-box';
+  const innerBody = document.createElement('div');
+  innerBody.className = 'inner-box';
+  innerBody.style.marginTop = '150px';
+  const input2 = document.createElement('input');
+  innerBody.appendChild(input2);
+  outerBody.appendChild(innerBody);
+  document.body.appendChild(outerBody);
+
+  const sb = TsuggestionBox.getInstance();
+  // Place the box on the dialog layer so overlays don't cover it
+  DOM.baseLayer?.subLayers.dialog?.appendChild(sb);
+
+  function attachSuggestions(inp) {
+    const update = () => {
+      const val = inp.value.trim().toLowerCase();
+      const suggestions = ['one','two','three'].filter(s => s.startsWith(val));
+      sb.showFor(inp, suggestions, v => (inp.value = v));
+    };
+    inp.addEventListener('input', update);
+    inp.addEventListener('focus', update);
+    inp.addEventListener('blur', () => sb.hide());
+    // keep popup aligned when any ancestor scrolls
+    let p = inp.parentElement;
+    while (p) {
+      p.addEventListener('scroll', () => sb.popup());
+      p = p.parentElement;
+    }
+  }
+
+  attachSuggestions(input1);
+  attachSuggestions(input2);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Demonstrate TsuggestionBox alignment using inputs inside a Twindow and inside the document body
- Provide nested scrollable parent containers to verify popup positioning
- Use the dialog layer for TsuggestionBox instead of manual z-index and update suggestions on focus/input

## Testing
- `node gridprj/tests/twindow.test.mjs` *(fails: DOMRect is not defined)*
- `node gridprj/tests/boxmodel-panel.test.mjs` *(fails: HTMLCanvasElement.prototype.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_6891d18a7f7083309fda7af2a33c75bd