### PR TITLE
Fix pagePos to account for scrolling ancestors

### DIFF
--- a/gridprj/files/js/src/dom/geometry.js
+++ b/gridprj/files/js/src/dom/geometry.js
@@ -175,19 +175,21 @@ apply();
 });
 }
 static pagePos(el) {
-let x = 0,
-y = 0,
-n = el;
-while (n) {
-x += n.offsetLeft - n.scrollLeft;
-y += n.offsetTop - n.scrollTop;
-n = n.offsetParent;
-}
-return {
-x: x + scrollX,
-y: y + scrollY
-};
-}
+        let x = 0, y = 0;
+        let n = el;
+        let op = el;
+        while (n) {
+            if (n === op) {
+                x += n.offsetLeft;
+                y += n.offsetTop;
+                op = n.offsetParent;
+            }
+            x -= n.scrollLeft;
+            y -= n.scrollTop;
+            n = n.parentElement;
+        }
+        return { x: x + scrollX, y: y + scrollY };
+    }
 static viewToElement(el, xOrPt = 0, y = 0) {
 const p = el.offsetParent || document.body;
 const r = p.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- simplify `TelementPoint.pagePos` to traverse ancestors once, adding offsets for offset parents and subtracting scroll for each element

## Testing
- `node tests/boxmodel-panel.test.mjs` *(fails: Not implemented: HTMLCanvasElement.prototype.getContext)*
- `node tests/twindow.test.mjs` *(fails: DOMRect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68925714919c8330ad2d7331208ccb0c