### PR TITLE
Reposition suggestion box during scroll

### DIFF
--- a/gridprj/files/js/src/ui/TsuggestionBox.js
+++ b/gridprj/files/js/src/ui/TsuggestionBox.js
@@ -31,6 +31,7 @@ export class TsuggestionBox extends TabsoluteElement {
         this.hide();
         this.items = [];
         this.selectedIndex = -1;
+        this._scrollHandler = () => this.#reposition();
         TsuggestionBox.#instance = this;
     }
 
@@ -43,6 +44,7 @@ export class TsuggestionBox extends TabsoluteElement {
         this.htmlObject.style.width = input.getBoundingClientRect().width + 'px';
         this.update(suggestions, onSelect);
         this.popup();
+        window.addEventListener('scroll', this._scrollHandler, true);
     }
 
     update(suggestions, onSelect) {
@@ -75,6 +77,17 @@ export class TsuggestionBox extends TabsoluteElement {
 
     getSelected() {
         return this.items[this.selectedIndex] ?? null;
+    }
+
+    hide() {
+        super.hide();
+        window.removeEventListener('scroll', this._scrollHandler, true);
+    }
+
+    #reposition() {
+        if (this.status?.visible && this.targetElement) {
+            this.rect.alignTo(this.targetElement, this.align, this.offsetX, this.offsetY);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- realign suggestion box when the page scrolls so it stays attached to its input

## Testing
- `node tests/boxmodel-panel.test.mjs` *(fails: HTMLCanvasElement.getContext not implemented)*
- `node tests/twindow.test.mjs` *(fails: DOMRect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68925bc8d0508330b00589be21543ea8