### PR TITLE
Use setProperty for style updates

### DIFF
--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -915,7 +915,9 @@ this.status.sizable = true;
                     const cssName = toKebabCase(i);
                     if (cssProps.properties[cssName]) {
                       const control = TControlFactory.createControl(cssName, obj.ownerElement || obj._element || obj, (val) => {
-                        obj[i] = val;
+                        const important = /\s*!important\s*$/i.test(val);
+                        const value = important ? val.replace(/\s*!important\s*$/i, '').trim() : val;
+                        obj.setProperty(cssName, value, important ? 'important' : '');
                       });
                       ns = control;
                       ns.firstChild.style.width = '100%';


### PR DESCRIPTION
## Summary
- Use `CSSStyleDeclaration.setProperty` when applying style changes in `findsubprops`
- Properly handle dashed property names and `!important` priority

## Testing
- `node tests/boxmodel-panel.test.mjs` *(fails: Not implemented: HTMLCanvasElement.prototype.getContext)*
- `node tests/twindow.test.mjs` *(fails: ReferenceError: DOMRect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6893b3f51d008330a292a6f0396b627b