### PR TITLE
feat: add css function metadata

### DIFF
--- a/gridprj/files/js/src/data/cssProperties.js
+++ b/gridprj/files/js/src/data/cssProperties.js
@@ -3380,6 +3380,16 @@ export const cssProps = {
       }
     }
   },
+    "functions": {
+      "linear-gradient": {
+        "params": ["<angle>", "<color-stop>", "<color-stop>"],
+        "template": "linear-gradient(<angle>, <color-stop>, <color-stop>)"
+      },
+      "radial-gradient": {
+        "params": ["<shape-size>", "<position>", "<color-stop>", "<color-stop>"],
+        "template": "radial-gradient(<shape-size> at <position>, <color-stop>, <color-stop>)"
+      }
+    },
     // Diğer veri setleri (font-family isimleri vb.)
     "familyNames": [
         "Times New Roman", "Georgia", "Garamond", "Arial", "Helvetica", "Verdana", "Courier New", "Lucida Console", "Impact", "Comic Sans MS"


### PR DESCRIPTION
## Summary
- add metadata for CSS functions like `linear-gradient` and `radial-gradient`
- include parameter placeholders and usage templates for gradients

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68948bc68444833081c5000d400b2c94