### PR TITLE
Add function template insertion to autocomplete

### DIFF
--- a/gridprj/files/js/src/ui/style-editor/controls/TautoCompleteControl.js
+++ b/gridprj/files/js/src/ui/style-editor/controls/TautoCompleteControl.js
@@ -1,4 +1,5 @@
 
+import { cssProps } from '../../../data/cssProperties.js';
 import { TbaseControl } from './TbaseControl.js';
 // --- OTOMATİK TAMAMLAMA KONTROLÜ ---
 export class TautoCompleteControl extends TbaseControl {
@@ -29,15 +30,43 @@ export class TautoCompleteControl extends TbaseControl {
 
         input.addEventListener('change', () => {
             let val = input.value.trim();
-            if (val.startsWith('[fn:') && val.endsWith(']')) {
-                val = val.slice(4, -1) + '()';
-                input.value = val;
-            }
-            this.onChange(val);
-            if (val.endsWith('()')) {
-                const pos = val.indexOf('()') + 1;
-                input.setSelectionRange(pos, pos);
+
+            // Normalize [fn:*] tokens or bare function calls
+            const fnTokenMatch = val.match(/^\[fn:([a-zA-Z-]+)\]$/);
+            const fnCallMatch = val.match(/^([a-zA-Z-]+)\(\)$/);
+            const fnName = fnTokenMatch ? fnTokenMatch[1] : (fnCallMatch ? fnCallMatch[1] : null);
+
+            if (fnName) {
+                const template = (cssProps.functions && cssProps.functions[fnName]) || `${fnName}()`;
+                input.value = template;
+                val = template;
+
+                const placeholderMatch = /<[^>]+>/.exec(template);
+                if (placeholderMatch) {
+                    const start = placeholderMatch.index + 1;
+                    const end = start + placeholderMatch[0].length - 2;
+                    input.setSelectionRange(start, end);
+                } else {
+                    const pos = template.indexOf('()') + 1;
+                    if (pos > 0) input.setSelectionRange(pos, pos);
+                }
                 input.focus();
+            }
+
+            this.onChange(val);
+        });
+
+        input.addEventListener('keydown', e => {
+            if (e.key === 'Tab') {
+                const value = input.value;
+                const placeholders = Array.from(value.matchAll(/<[^>]+>/g));
+                if (placeholders.length) {
+                    e.preventDefault();
+                    let idx = placeholders.findIndex(p => input.selectionStart >= p.index && input.selectionStart <= p.index + p[0].length);
+                    idx = (idx + 1) % placeholders.length;
+                    const ph = placeholders[idx];
+                    input.setSelectionRange(ph.index + 1, ph.index + ph[0].length - 1);
+                }
             }
         });
         


### PR DESCRIPTION
## Summary
- insert associated templates from `cssProperties.functions` when selecting function suggestions
- place caret at first placeholder and allow tabbing through remaining placeholders

## Testing
- `node gridprj/tests/boxmodel-panel.test.mjs` *(fails: HTMLCanvasElement.prototype.getContext not implemented)*
- `npm install canvas` *(fails: 403 Forbidden)*
- `node gridprj/tests/twindow.test.mjs` *(fails: DOMRect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68948bd3135883308d7b8a07da5c3944