### PR TITLE
Remove grid styling from specialized tabs

### DIFF
--- a/gridprj/files/css/propeditor.css
+++ b/gridprj/files/css/propeditor.css
@@ -3,6 +3,8 @@
 .TpropEditor .dots{width:100%;height:100%;overflow:hidden;display:table;table-layout:fixed;}
 .TpropEditor .dots div{height:100%;box-sizing:border-box;display:table-cell;width:100%;overflow:hidden;}
 .TpropEditor .dots p{display:table-cell;width:20px;font-weight:bolder;text-align:center;background-color:#ddd;border:solid gray 1px;color:blue;cursor:pointer;}
+/* Removing grid appearance for select tabs */
+.TpropEditor .no-grid td{border-top:none;border-bottom:none;}
 #codeditor{background-color: #272822;overflow: visible;}
 
 .TpropEditor .propdiv{width: 100%; height: 18px;overflow: hidden;text-wrap: nowrap; font-size: small; font-family: monospace; font-weight: 700;user-select: none;display:flex;flex-direction: row;}

--- a/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
+++ b/gridprj/files/js/src/ui/prop-editor/TlegacyPropEditor.js
@@ -482,6 +482,7 @@ this.status.sizable = true;
     // styles.  Additional tabs expose general properties, functions and
     // events.
     const tabNames = ['style', 'box', 'color', 'transform', 'animation', 'props', 'functions', 'events'];
+    const gridlessTabs = ['box', 'color', 'transform', 'animation'];
     this.tabBar = document.createElement('ul');
     this.tabBar.className = 'prop-tab-bar';
     this.tabBar.style.cssText = 'list-style:none;margin:0;padding:0;display:flex;border-bottom:1px solid #ccc;';
@@ -498,7 +499,7 @@ this.status.sizable = true;
       li.onclick = () => this.switchTab(name);
       this.tabBar.appendChild(li);
 
-      const area = this.createTabArea();
+      const area = this.createTabArea(gridlessTabs.includes(name));
       area.container.style.display = 'none';
       tabContainer.appendChild(area.container);
       area.tab = li;
@@ -549,9 +550,10 @@ this.status.sizable = true;
     this.viewObject(window);
   }
 
-  createTabArea() {
+  createTabArea(noGrid = false) {
     const cntx = document.createElement('div');
     cntx.style.cssText = 'width:100%;overflow:hidden;height:100%;display:inline-block;background-color:#fefefe;white-space:nowrap';
+    if (noGrid) cntx.classList.add('no-grid');
 
     const cp = document.createElement('div');
     cp.className = 'prop-keys';


### PR DESCRIPTION
## Summary
- Avoid grid styling on box, color, transform, and animation tabs in `TlegacyPropEditor`.
- Add a `no-grid` class to disable borders in those tabs.

## Testing
- `node tests/twindow.test.mjs` *(fails: RangeError: Maximum call stack size exceeded)*
- `node tests/boxmodel-panel.test.mjs` *(fails: HTMLCanvasElement.prototype.getContext not implemented; npm install canvas 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895048bb1108330b9d99b16d85feb5f